### PR TITLE
CI: fail when no template fixtures are found

### DIFF
--- a/MarineSABRES_SES_Shiny/.github/workflows/test.yml
+++ b/MarineSABRES_SES_Shiny/.github/workflows/test.yml
@@ -75,7 +75,9 @@ jobs:
             file.copy(fixtures, "data", overwrite = TRUE)
             message(sprintf("Copied %i fixture(s) into data/", length(fixtures)))
           } else {
-            message("No fixture JSON files found in tests/fixtures/templates")
+            message("ERROR: No fixture JSON files found in tests/fixtures/templates. Ensure fixtures are committed to tests/fixtures/templates.")
+            # Fail the step to make missing fixtures clearly visible in CI
+            stop("No fixture JSON files found in tests/fixtures/templates")
           }
         shell: Rscript {0}
 


### PR DESCRIPTION
Add CI assertion to fail early when no template fixtures are present in tests/fixtures/templates to enforce deterministic template tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture validation to enforce stricter error handling, ensuring the test suite fails early when test data is missing rather than continuing with incomplete configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->