### PR TITLE
CI: report number and names of copied fixtures

### DIFF
--- a/MarineSABRES_SES_Shiny/.github/workflows/test.yml
+++ b/MarineSABRES_SES_Shiny/.github/workflows/test.yml
@@ -81,6 +81,18 @@ jobs:
           }
         shell: Rscript {0}
 
+      - name: Report fixture count
+        run: |
+          # Count JSON fixtures present in data/ and print for diagnostics
+          n <- length(list.files("data", pattern = "\\.json$", full.names = TRUE))
+          message(sprintf("Fixtures present in data/: %d", n))
+          # Also list files for easier debugging
+          files <- list.files("data", pattern = "\\.json$", full.names = TRUE)
+          if (length(files) > 0) {
+            message(paste("Files:", paste(basename(files), collapse = ", ")))
+          }
+        shell: Rscript {0}
+
       - name: Run tests
         run: |
           library(testthat)


### PR DESCRIPTION
Add a CI step to print the number and filenames of JSON fixtures copied into data/ for easier diagnostics when tests run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test workflow diagnostics to report fixture preparation status during CI/CD pipeline execution.

---

**Note:** This release contains only internal infrastructure updates with no visible impact to end-users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->