### PR TITLE
CI: upload fixture list as artifact

### DIFF
--- a/MarineSABRES_SES_Shiny/.github/workflows/test.yml
+++ b/MarineSABRES_SES_Shiny/.github/workflows/test.yml
@@ -93,6 +93,24 @@ jobs:
           }
         shell: Rscript {0}
 
+      - name: Persist fixture list to artifact
+        run: |
+          files <- list.files("data", pattern = "\\.json$", full.names = TRUE)
+          if (length(files) == 0) {
+            writeLines(character(0), "fixture_list.txt")
+          } else {
+            writeLines(files, "fixture_list.txt")
+          }
+          message(sprintf("Wrote %d fixture(s) to fixture_list.txt", length(files)))
+        shell: Rscript {0}
+
+      - name: Upload fixture list artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: fixture-list
+          path: fixture_list.txt
+
       - name: Run tests
         run: |
           library(testthat)


### PR DESCRIPTION
Add CI steps to write the list of JSON fixtures copied into data/ to fixture_list.txt and upload it as an artifact for easier diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal test infrastructure to improve fixture management and artifact handling in the testing workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->