### PR TITLE
fix(feedback): rename input$feedback_browser_info → input$fb_browser_info

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/feedback_reporter.R
+++ b/MarineSABRES_SES_Shiny/functions/feedback_reporter.R
@@ -48,8 +48,12 @@ collect_system_context <- function(session     = NULL,
   }) %||% "unknown"
 
   # --- browser_info ----------------------------------------------------------
+  # NOTE: input is `fb_browser_info` (set by tags$script in server/modals.R:1644
+  # after the v0.x ef005fb rename from `feedback_*` to `fb_*`). The previous
+  # value `feedback_browser_info` here meant every submission had
+  # browser_info = "unknown".
   browser_info <- tryCatch({
-    val <- if (!is.null(input)) input$feedback_browser_info else NULL
+    val <- if (!is.null(input)) input$fb_browser_info else NULL
     if (is.null(val) || identical(val, "")) "unknown" else as.character(val)
   }, error = function(e) {
     if (exists("debug_log", mode = "function")) debug_log(paste("collect_system_context browser_info:", e$message), "WARN")

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-reporter.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-reporter.R
@@ -35,8 +35,8 @@ test_that("collect_system_context returns all expected fields", {
               "collect_system_context not available")
 
   mock_input <- list(
-    sidebar              = "cld_visualization",
-    feedback_browser_info = "Mozilla/5.0 (Test)"
+    sidebar          = "cld_visualization",
+    fb_browser_info  = "Mozilla/5.0 (Test)"  # matches server/modals.R:1644 (Shiny.setInputValue)
   )
 
   mock_project <- list(


### PR DESCRIPTION
## Summary

User-reported bug ("Feedback neveikia"). The navbar Feedback modal lost browser context on every submission because of an input-ID rename mismatch.

\`functions/feedback_reporter.R:52\` read \`input\$feedback_browser_info\`, but commit \`ef005fb\` renamed all modal inputs to \`fb_*\` prefix. The JS at \`server/modals.R:1644\` writes \`input\$fb_browser_info\`. Since the rename, every submission's \`browser_info\` field has been silently "unknown".

## Changes (2 files, +7/-3)

- \`functions/feedback_reporter.R:52\` — read \`input\$fb_browser_info\` instead of \`input\$feedback_browser_info\`. Inline comment noting the rename to prevent regression.
- \`tests/testthat/test-feedback-reporter.R:39\` — mock_input uses the new input name.

## Test plan

- [x] \`test-feedback-reporter.R\` → 226/226 (was 225/1)
- [ ] Manual: open navbar Feedback modal, submit, inspect \`data/user_feedback_log.ndjson\` → confirm \`browser_info\` is the real User-Agent string instead of "unknown"

## Notes for reviewer

- The other \`input\$feedback_*\` references in \`modules/feedback_admin_module.R:326-327\` are DT-generated input names (\`feedback_table_rows_selected\`) — different namespace, intentionally not renamed.
- This PR is independent of PR #14 (ISA Data Entry persistence). Either can merge first; no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where browser information was not being properly captured in user feedback submissions and would incorrectly display as "unknown."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razinkele/SESTool/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->