### PR TITLE
fix(scenario-builder): replace silent req() with guards in 'Add new link'

### DIFF
--- a/MarineSABRES_SES_Shiny/modules/scenario_builder_module.R
+++ b/MarineSABRES_SES_Shiny/modules/scenario_builder_module.R
@@ -528,24 +528,62 @@ scenario_builder_server <- function(id, project_data_reactive, i18n, event_bus =
       showNotification(i18n$t("modules.scenario.builder.scenario_node_marked_for_removal"), type = "message")
     })
 
-    # Add link dialog
+    # Add link dialog ----
+    # Previously used silent req() guards: if any precondition failed (no
+    # project loaded, CLD not built, no active scenario, etc.), the observer
+    # aborted silently and the user perceived the "Add new link" button as
+    # frozen / dead. Replaced with explicit guards that surface a toast so
+    # the user knows what to fix before the modal can open.
     observeEvent(input$add_link, {
-      req(project_data_reactive())
-      data <- project_data_reactive()
-      req(data$data$cld$nodes)
+      pd <- project_data_reactive()
+      if (is.null(pd)) {
+        showNotification(i18n$t("common.messages.error_no_project_data"),
+                         type = "warning", duration = 5)
+        return()
+      }
+
+      if (is.null(pd$data$cld$nodes) || nrow(pd$data$cld$nodes) == 0) {
+        showNotification(i18n$t("modules.scenario.builder.scenario_no_cld_found"),
+                         type = "warning", duration = 5)
+        return()
+      }
+
+      if (is.null(active_scenario_id())) {
+        showNotification(i18n$t("modules.scenario.builder.scenario_no_scenarios_yet"),
+                         type = "warning", duration = 5)
+        return()
+      }
+
+      active_scenario <- tryCatch(get_active_scenario(), error = function(e) NULL)
+      if (is.null(active_scenario)) {
+        showNotification(i18n$t("modules.scenario.builder.scenario_no_scenarios_yet"),
+                         type = "warning", duration = 5)
+        return()
+      }
 
       # Get all available nodes (baseline + added in scenario)
-      active_scenario <- get_active_scenario()
+      data <- pd
       base_nodes <- data$data$cld$nodes$id
-      added_nodes <- sapply(active_scenario$modifications$nodes_added, function(n) n$id)
+      added_nodes <- if (length(active_scenario$modifications$nodes_added) > 0) {
+        vapply(active_scenario$modifications$nodes_added, function(n) n$id, character(1))
+      } else character(0)
       all_nodes <- c(base_nodes, added_nodes)
 
       base_labels <- setNames(data$data$cld$nodes$label, data$data$cld$nodes$id)
-      added_labels <- setNames(
-        sapply(active_scenario$modifications$nodes_added, function(n) n$label),
-        sapply(active_scenario$modifications$nodes_added, function(n) n$id)
-      )
+      added_labels <- if (length(active_scenario$modifications$nodes_added) > 0) {
+        setNames(
+          vapply(active_scenario$modifications$nodes_added, function(n) n$label, character(1)),
+          vapply(active_scenario$modifications$nodes_added, function(n) n$id, character(1))
+        )
+      } else character(0)
       all_labels <- c(base_labels, added_labels)
+
+      # Need at least 2 distinct nodes to form a link
+      if (length(all_labels) < 2) {
+        showNotification(i18n$t("modules.scenario.builder.scenario_need_cld_first"),
+                         type = "warning", duration = 5)
+        return()
+      }
 
       showModal(modalDialog(
         title = i18n$t("modules.scenario.builder.scenario_add_new_link"),


### PR DESCRIPTION
## Summary

User-reported: clicking "Add new link" in Scenario Builder sometimes did nothing (apparent freeze) and other times opened a modal with empty dropdowns. Root cause: three silent \`req()\` calls in the observer aborted without telling the user what's missing.

## Changes (1 file, +48/-10)

\`modules/scenario_builder_module.R:532-590\` — replaced the silent \`req()\` chain with explicit guards that call \`showNotification(...)\` then \`return()\`:

1. \`is.null(project_data_reactive())\` → toast "Error: No project data available"
2. \`nrow(pd\$data\$cld\$nodes) == 0\` → toast "Scenario No Cld Found"  
3. \`is.null(active_scenario_id())\` → toast "Scenario No Scenarios Yet"
4. \`is.null(get_active_scenario())\` → same as #3 (defensive)
5. \`length(all_labels) < 2\` → toast "Scenario Need Cld First"

Also replaced \`sapply\` with \`vapply\` for type-safe extraction of node ids/labels from the scenario modifications list, and added length-guard so the modal isn't opened on an empty added-nodes list.

## i18n note

Existing translation keys are reused — no new keys added. Some keys have placeholder-quality English values (e.g., "Scenario No Cld Found") inherited from earlier auto-generation; the wording isn't great but the user now sees *something* and knows to act. A follow-up i18n cleanup PR can improve these messages across all 9 languages.

## Test plan

- [x] \`test-scenario-builder-module.R\` → 8/8
- [x] \`test-i18n-enforcement.R\` → 37/37
- [ ] Manual: open Scenario Builder before loading a project → click "Add new link" → expect toast, not silence
- [ ] Manual: open with empty CLD → click "Add new link" → expect "Scenario No Cld Found" toast
- [ ] Manual: open with CLD but no scenario created → click → expect "no scenarios yet" toast

## Related

Third PR closing user-reported bugs from a single feedback report:
- #14 — Standard Entry persistence (data loss + ghost duplicates)
- #15 — Feedback modal browser_info
- #16 (this) — Scenario Builder linking guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of the "Add link" modal—now displays warning notifications instead of silently failing when required data is missing (e.g., project data, scenario selection).
  * Enhanced link creation validation to require at least two selectable nodes before allowing link addition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razinkele/SESTool/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->