### PR TITLE
test: make the 5 brittle module tests behavioral (not signature-only)

### DIFF
--- a/MarineSABRES_SES_Shiny/tests/testthat/test-export-reports-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-export-reports-module.R
@@ -10,6 +10,12 @@ library(shiny)
 source_for_test("modules/export_reports_module.R")
 i18n <- list(t = function(key) key)
 
+# Re-bind the real server over the helper-stubs.R stub, which shadows the
+# .GlobalEnv copy in testthat's helper env (see feedback_testserver_stub_shadowing).
+if (exists("export_reports_server", envir = .GlobalEnv)) {
+  export_reports_server <- get("export_reports_server", envir = .GlobalEnv)
+}
+
 # ============================================================================
 # UI FUNCTION TESTS
 # ============================================================================
@@ -56,4 +62,23 @@ test_that("export_reports_server event_bus defaults to NULL", {
   default <- formals(export_reports_server)$event_bus
   expect_true(is.null(default) || identical(as.character(default), "NULL"),
               info = "event_bus must default to NULL for backward compatibility")
+})
+
+# ============================================================================
+# SERVER BEHAVIOR TESTS
+# Actual report generation drives rmarkdown (heavy/pandoc) so we don't trigger
+# it here; instead assert the server instantiates and renders its real output,
+# which the stub cannot produce -> FAILS if the server body is NULL.
+# ============================================================================
+
+test_that("server instantiates and renders the namespaced report-status output", {
+  testServer(export_reports_server,
+             args = list(project_data_reactive = reactiveVal(init_session_data()),
+                         i18n = i18n), {
+    session$flushReact()
+    rendered <- paste(as.character(output$report_status), collapse = "")
+    expect_true(nzchar(rendered))
+    # the real renderUI body builds a div with this namespaced id
+    expect_match(rendered, "report_status_div")
+  })
 })

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-admin-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-admin-module.R
@@ -12,6 +12,12 @@ source_for_test("modules/feedback_admin_module.R")
 # Mock i18n
 i18n <- list(t = function(key) key)
 
+# Re-bind the real server over the helper-stubs.R stub, which shadows the
+# .GlobalEnv copy in testthat's helper env (see feedback_testserver_stub_shadowing).
+if (exists("feedback_admin_server", envir = .GlobalEnv)) {
+  feedback_admin_server <- get("feedback_admin_server", envir = .GlobalEnv)
+}
+
 # ============================================================================
 # UI FUNCTION TESTS
 # ============================================================================
@@ -72,4 +78,30 @@ test_that("feedback_admin_server event_bus defaults to NULL", {
   # In R, a NULL default is represented as symbol 'NULL' when retrieved via formals()
   expect_true(is.null(default) || identical(as.character(default), "NULL"),
               info = "event_bus must default to NULL for backward compatibility")
+})
+
+# ============================================================================
+# SERVER BEHAVIOR TESTS
+# The module loads the feedback log on start and renders value boxes + tables.
+# These read the real outputs, so they FAIL if the server body is NULL.
+# ============================================================================
+
+test_that("load-on-start renders the summary value boxes and feedback table", {
+  testServer(feedback_admin_server, args = list(i18n = i18n), {
+    session$flushReact()
+    # value boxes are computed from the loaded feedback log (empty df in test env)
+    expect_false(is.null(output$vbox_total))
+    expect_false(is.null(output$vbox_bugs))
+    expect_false(is.null(output$vbox_suggestions))
+    # the feedback DataTable renders
+    expect_false(is.null(output$feedback_table))
+  })
+})
+
+test_that("find_duplicates observer runs and the duplicates table renders", {
+  testServer(feedback_admin_server, args = list(i18n = i18n), {
+    session$flushReact()
+    session$setInputs(find_duplicates = 1)        # increments run_detection
+    expect_false(is.null(output$duplicates_table))
+  })
 })

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-prepare-report-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-prepare-report-module.R
@@ -9,6 +9,12 @@ source_for_test("modules/prepare_report_module.R")
 # Mock i18n
 i18n <- list(t = function(key) key)
 
+# Re-bind the real server over the helper-stubs.R stub, which shadows the
+# .GlobalEnv copy in testthat's helper env (see feedback_testserver_stub_shadowing).
+if (exists("prepare_report_server", envir = .GlobalEnv)) {
+  prepare_report_server <- get("prepare_report_server", envir = .GlobalEnv)
+}
+
 # ============================================================================
 # UI FUNCTION TESTS
 # ============================================================================
@@ -60,6 +66,41 @@ test_that("prepare_report_server has correct parameters", {
   expect_true("id" %in% params)
   expect_true("project_data_reactive" %in% params)
   expect_true("i18n" %in% params)
+})
+
+# ============================================================================
+# SERVER BEHAVIOR TESTS
+# check_prerequisites() reads the project and prerequisite_status renders
+# success/danger icons accordingly. These read the real output and differ by
+# input, so they FAIL if the server body is replaced with NULL. (Report
+# generation itself drives rmarkdown/officer and is covered by the helper
+# tests below, not the server observers.)
+# ============================================================================
+
+test_that("prerequisite_status shows danger icons when loops/leverage are absent", {
+  testServer(prepare_report_server,
+             args = list(project_data_reactive = reactiveVal(list(data = list())),
+                         i18n = i18n), {
+    session$flushReact()
+    html <- paste(as.character(output$prerequisite_status), collapse = "")
+    expect_true(nzchar(html))
+    expect_match(html, "text-danger")             # neither prerequisite met
+    expect_false(grepl("text-success", html, fixed = TRUE))
+  })
+})
+
+test_that("prerequisite_status shows success icons when loops + leverage are present", {
+  ready <- reactiveVal(list(data = list(
+    analysis = list(loops = list(list(1), list(2))),          # has_loops: length > 0
+    cld = list(nodes = data.frame(leverage_score = c(0.5, 0.2)))  # has_leverage: any > 0
+  )))
+  testServer(prepare_report_server,
+             args = list(project_data_reactive = ready, i18n = i18n), {
+    session$flushReact()
+    html <- paste(as.character(output$prerequisite_status), collapse = "")
+    expect_match(html, "text-success")            # both prerequisites met
+    expect_false(grepl("text-danger", html, fixed = TRUE))
+  })
 })
 
 # ============================================================================

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-recent-projects-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-recent-projects-module.R
@@ -10,6 +10,12 @@ library(shiny)
 source_for_test("modules/recent_projects_module.R")
 i18n <- list(t = function(key) key)
 
+# Re-bind the real server over the helper-stubs.R stub, which shadows the
+# .GlobalEnv copy in testthat's helper env (see feedback_testserver_stub_shadowing).
+if (exists("recent_projects_server", envir = .GlobalEnv)) {
+  recent_projects_server <- get("recent_projects_server", envir = .GlobalEnv)
+}
+
 # ============================================================================
 # UI FUNCTION TESTS
 # ============================================================================
@@ -56,4 +62,46 @@ test_that("recent_projects_server event_bus defaults to NULL", {
   default <- formals(recent_projects_server)$event_bus
   expect_true(is.null(default) || identical(as.character(default), "NULL"),
               info = "event_bus must default to NULL for backward compatibility")
+})
+
+# ============================================================================
+# SERVER BEHAVIOR TESTS
+# The module returns list(get_projects, refresh, is_local_mode). These drive
+# that real interface, so they FAIL if the server body is replaced with NULL.
+# ============================================================================
+
+test_that("server returns the documented project interface and computes state", {
+  testServer(recent_projects_server,
+             args = list(project_data_reactive = reactiveVal(init_session_data()),
+                         i18n = i18n), {
+    session$flushReact()
+    ret <- session$getReturned()
+    expect_true(is.list(ret))
+    expect_true(all(c("get_projects", "refresh", "is_local_mode") %in% names(ret)))
+    # init observe block populated state from the environment
+    expect_s3_class(ret$get_projects(), "data.frame")
+    expect_type(ret$is_local_mode(), "logical")
+    expect_true(is.function(ret$refresh))
+  })
+})
+
+test_that("refresh() reloads the projects data frame without error", {
+  testServer(recent_projects_server,
+             args = list(project_data_reactive = reactiveVal(init_session_data()),
+                         i18n = i18n), {
+    session$flushReact()
+    ret <- session$getReturned()
+    ret$refresh()                              # list_saved_projects(state$projects_folder)
+    expect_s3_class(ret$get_projects(), "data.frame")
+  })
+})
+
+test_that("dismiss_tip removes the onboarding tip output", {
+  testServer(recent_projects_server,
+             args = list(project_data_reactive = reactiveVal(init_session_data()),
+                         i18n = i18n), {
+    session$setInputs(dismiss_tip = 1)
+    # show_onboarding flipped FALSE -> the renderUI short-circuits to NULL
+    expect_null(output$onboarding_tip)
+  })
 })

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-template-ses-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-template-ses-module.R
@@ -10,6 +10,14 @@ library(shiny)
 source_for_test("modules/template_ses_module.R")
 i18n <- list(t = function(key) key)
 
+# source_for_test() writes the real module to .GlobalEnv, but helper-stubs.R
+# defines a stub template_ses_server in testthat's helper env which SHADOWS it
+# during lookup. Re-bind the real server here so testServer() drives the real
+# module, not the stub (see feedback_testserver_stub_shadowing).
+if (exists("template_ses_server", envir = .GlobalEnv)) {
+  template_ses_server <- get("template_ses_server", envir = .GlobalEnv)
+}
+
 # ============================================================================
 # UI FUNCTION TESTS
 # ============================================================================
@@ -72,4 +80,41 @@ test_that("template_ses_server optional params default to NULL", {
       expect_true(is.null(default) || identical(as.character(default), "NULL"),
                   info = paste0("user_level_reactive should default to NULL for optional use"))
     }
+})
+
+# ============================================================================
+# SERVER BEHAVIOR TESTS
+# These drive observers and assert observable effects, so they FAIL if the
+# server body is replaced with NULL (unlike the signature checks above).
+# ============================================================================
+
+# paste(as.character(...), collapse="") flattens a shiny tag / NULL to one
+# string so emptiness and content checks are robust to length.
+.render_chr <- function(x) paste(as.character(x), collapse = "")
+
+test_that("selecting a template flips template_actions from empty to rendered", {
+  testServer(template_ses_server,
+             args = list(project_data_reactive = reactiveVal(init_session_data()),
+                         i18n = i18n), {
+    before <- .render_chr(output$template_actions)
+    expect_false(nzchar(before))                 # nothing selected -> renderUI is empty
+
+    session$setInputs(template_selected = "fisheries")
+
+    after <- .render_chr(output$template_actions)
+    expect_true(nzchar(after))                   # selection observer set rv$selected_template
+    expect_match(after, "well", info = "actions panel (wellPanel) now rendered")
+  })
+})
+
+test_that("template_cards renders a card per available template", {
+  testServer(template_ses_server,
+             args = list(project_data_reactive = reactiveVal(init_session_data()),
+                         i18n = i18n), {
+    cards <- .render_chr(output$template_cards)
+    expect_true(nzchar(cards))
+    # build_entry style: each template renders a div with class 'template-card'
+    n_cards <- length(gregexpr("template-card\"", cards, fixed = TRUE)[[1]])
+    expect_gt(n_cards, 0)
+  })
 })


### PR DESCRIPTION
@
## Why

CLAUDE.md flags 6 module tests as **signature-only** — they assert functions exist with the right params but "would pass even if the module body were replaced with `function(...) NULL`." `entry-point` was already rewritten; this does the remaining **5**: `feedback-admin`, `recent-projects`, `template-ses`, `export-reports`, `prepare-report`.

## What

Each test now drives the **real** server via `testServer()` and asserts an observable effect, so it **fails if the server body is NULL**:

- **template-ses** — selecting a template flips `output$template_actions` empty→rendered; `template_cards` renders a card per template
- **recent-projects** — the returned `list(get_projects, refresh, is_local_mode)` interface; `dismiss_tip` observer
- **feedback-admin** — load-on-start renders value boxes + feedback DataTable; `find_duplicates` observer
- **export-reports** — server instantiates and renders the namespaced report-status output (Rmd generation left to helper coverage)
- **prepare-report** — `prerequisite_status` renders `text-danger` vs `text-success` icons depending on whether loop + leverage analysis exist — a real data→UI reaction

Key enabler: each file **re-binds the real server from `.GlobalEnv`** before `testServer()`. `source_for_test()` writes the real module to `.GlobalEnv`, but `helper-stubs.R` defines a stub in testthat helper env that *shadows* it — so prior "behavior" tests silently exercised the stub.

## Tests

All 5 files green: **88 passing, 0 failures** (17 / 15 / 13 / 10 / 33). Signature + UI contract tests retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for core application modules with new server behavior tests
  * Added verification tests to ensure all key outputs render correctly
  * Enhanced reactive behavior validation to confirm outputs display as expected based on data states and user interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razinkele/SESTool/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->