### PR TITLE
test: cover pilot_study_module (the last untested module)

### DIFF
--- a/MarineSABRES_SES_Shiny/CLAUDE.md
+++ b/MarineSABRES_SES_Shiny/CLAUDE.md
@@ -77,7 +77,7 @@ Rscript scripts/add_translation.R
 │   └── ARCHITECTURE.md   # Architecture Decision Records
 ├── scripts/
 │   └── build_offshore_wind_kb.py  # Reproducible KB builder from BibTeX (187 papers)
-└── tests/testthat/       # 92 test files, ~7000 assertions passing (21/22 *_module.R covered; pilot_study_module pending)
+└── tests/testthat/       # 92 test files, ~7000 assertions passing (all 22 *_module.R covered)
 ```
 
 ## i18n System (CRITICAL)
@@ -220,7 +220,7 @@ tryCatch({
 ## Testing
 
 - **Unit tests**: `test-global-utils.R`, `test-data-structure.R`
-- **Module signature-contract tests**: `test-<module-name>-module.R` for 21 of the 22 `modules/*_module.R` files (pilot_study_module.R is a v1.15.0 addition without a signature test yet). Each asserts UI returns valid shiny tags, namespaces IDs, server function exists with the conventional `(id, project_data_reactive, i18n, ..., event_bus = NULL)` signature. The previously signature-only set (entry-point, feedback-admin, recent-projects, template-ses, export-reports, prepare-report) now also carries **behavior tests** that drive the real server via `testServer()` and assert observable effects (so they fail if the module body is `NULL`). Pattern: each re-binds the real server from `.GlobalEnv` before `testServer()` because `helper-stubs.R` defines a stub in testthat's helper env that shadows the `.GlobalEnv` copy `source_for_test()` writes — without the re-bind, `testServer()` drives the stub. Reach internal state via the module's returned reactive (`session$getReturned()`), not module-local vars (testServer does not expose them here).
+- **Module signature-contract tests**: `test-<module-name>-module.R` for all 22 `modules/*_module.R` files. Each asserts UI returns valid shiny tags, namespaces IDs, server function exists with the conventional `(id, project_data_reactive, i18n, ..., event_bus = NULL)` signature. The previously signature-only set (entry-point, feedback-admin, recent-projects, template-ses, export-reports, prepare-report) now also carries **behavior tests** that drive the real server via `testServer()` and assert observable effects (so they fail if the module body is `NULL`). Pattern: each re-binds the real server from `.GlobalEnv` before `testServer()` because `helper-stubs.R` defines a stub in testthat's helper env that shadows the `.GlobalEnv` copy `source_for_test()` writes — without the re-bind, `testServer()` drives the stub. Reach internal state via the module's returned reactive (`session$getReturned()`), not module-local vars (testServer does not expose them here).
 - **Module integration tests**: `test-modules.R` (pre-existing `testServer()` exercises)
 - **JSON loading**: `test-json-project-loading.R` (standalone runner: `tests/run_json_loading_tests.R`)
 - **Integration**: `test-integration.R`

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-pilot-study-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-pilot-study-module.R
@@ -1,0 +1,102 @@
+# test-pilot-study-module.R
+# Unit + behavior tests for modules/pilot_study_module.R
+#
+# pilot_study_module had NO test (the lone uncovered modules/*_module.R file —
+# a v1.15.0 addition). This adds the UI/signature contract checks plus behavior
+# tests that drive the real server via testServer().
+
+library(testthat)
+library(shiny)
+
+# Source the module (modules/ are not auto-loaded by global.R).
+source_for_test("modules/pilot_study_module.R")
+i18n <- list(t = function(key) key)
+
+# Re-bind the real server over any helper-stubs.R stub, which shadows the
+# .GlobalEnv copy in testthat's helper env (see feedback_testserver_stub_shadowing).
+if (exists("pilot_study_server", envir = .GlobalEnv)) {
+  pilot_study_server <- get("pilot_study_server", envir = .GlobalEnv)
+}
+
+# ============================================================================
+# UI FUNCTION TESTS
+# ============================================================================
+
+test_that("pilot_study_ui function exists", {
+  skip_if_not(exists("pilot_study_ui", mode = "function"),
+              "pilot_study_ui not available")
+  expect_true(is.function(pilot_study_ui))
+})
+
+test_that("pilot_study_ui returns valid shiny tags and namespaces the id", {
+  skip_if_not(exists("pilot_study_ui", mode = "function"),
+              "pilot_study_ui not available")
+  params <- names(formals(pilot_study_ui))
+  ui <- if ("i18n" %in% params) pilot_study_ui("test_pilot", i18n) else pilot_study_ui("test_pilot")
+  expect_true(inherits(ui, "shiny.tag") || inherits(ui, "shiny.tag.list"))
+  expect_true(grepl("test_pilot", as.character(ui)),
+              info = "UI must namespace IDs with the module id")
+})
+
+# ============================================================================
+# SERVER FUNCTION TESTS
+# ============================================================================
+
+test_that("pilot_study_server function exists", {
+  skip_if_not(exists("pilot_study_server", mode = "function"),
+              "pilot_study_server not available")
+  expect_true(is.function(pilot_study_server))
+})
+
+test_that("pilot_study_server signature includes the required params", {
+  skip_if_not(exists("pilot_study_server", mode = "function"),
+              "pilot_study_server not available")
+  params <- names(formals(pilot_study_server))
+  for (p in c("id", "project_data_reactive", "i18n", "event_bus")) {
+    expect_true(p %in% params, info = paste0("Missing parameter: ", p))
+  }
+})
+
+test_that("pilot_study_server event_bus defaults to NULL", {
+  skip_if_not(exists("pilot_study_server", mode = "function"),
+              "pilot_study_server not available")
+  default <- formals(pilot_study_server)$event_bus
+  expect_true(is.null(default) || identical(as.character(default), "NULL"),
+              info = "event_bus must default to NULL for backward compatibility")
+})
+
+# ============================================================================
+# SERVER BEHAVIOR TESTS
+# Without a ?pilot_condition=A|B URL param the module stays inactive (the
+# default in testServer, where url_search is empty). These drive the real
+# returned interface + outputs, so they FAIL if the server body is NULL.
+# ============================================================================
+
+test_that("module is inactive by default and exposes the is_active + trigger interface", {
+  testServer(pilot_study_server,
+             args = list(project_data_reactive = reactiveVal(init_session_data()),
+                         i18n = i18n), {
+    session$flushReact()
+    ret <- session$getReturned()
+    expect_true(is.list(ret))
+    expect_true(all(c("is_active", "trigger_end_of_session") %in% names(ret)))
+    expect_false(ret$is_active())                  # no ?pilot_condition -> inactive
+    expect_true(is.function(ret$trigger_end_of_session))
+    expect_null(output$banner)                     # banner renderUI returns NULL while inactive
+    expect_silent(ret$trigger_end_of_session())    # no-op (no modal/error) while inactive
+  })
+})
+
+test_that("save tracker takes the inactive early-return path without error", {
+  pdr <- reactiveVal(init_session_data())
+  testServer(pilot_study_server,
+             args = list(project_data_reactive = pdr, i18n = i18n), {
+    session$flushReact()
+    # A project_data change fires the save-tracker observer; while inactive it
+    # must early-return (no recording, no error).
+    pdr(list(isa_data = list(elements = data.frame(id = 1:6),
+                             connections = data.frame(a = 1:4))))
+    session$flushReact()
+    expect_false(session$getReturned()$is_active())
+  })
+})


### PR DESCRIPTION
@
`pilot_study_module.R` (v1.15.0) was the only `modules/*_module.R` with **no test** (noted as pending in CLAUDE.md). Adds:

- UI contract: exists, returns shiny tags, namespaces the id
- Server signature: id / project_data_reactive / i18n / event_bus = NULL
- **Behavior** (testServer): inactive by default (no `?pilot_condition=A|B` URL), the returned `is_active` / `trigger_end_of_session` interface, banner hidden while inactive, and the save-tracker observer taking its inactive early-return path without error

16 assertions pass. All 22 `*_module.R` files now have tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@