### PR TITLE
fix: surface translated errors in dashboard + language-change handlers

### DIFF
--- a/MarineSABRES_SES_Shiny/server/dashboard.R
+++ b/MarineSABRES_SES_Shiny/server/dashboard.R
@@ -94,6 +94,12 @@ setup_dashboard_rendering <- function(input, output, session, project_data, i18n
       stats <- dashboard_stats()
       bs4ValueBox(stats$n_elements, i18n$t("ui.dashboard.total_elements"), icon = icon("circle"), color = "primary")
     }, error = function(e) {
+      # Per-box notification id keeps each value-box error to a single toast
+      # (re-renders replace it) — bounded to 4 toasts max, no hash collisions.
+      showNotification(
+        format_user_error(e, i18n = i18n, context_key = "common.messages.context_dashboard_stats"),
+        type = "error", id = "dashboard_err_box1", session = session
+      )
       bs4ValueBox(0, i18n$t("ui.dashboard.error"), icon = icon("times"), color = "danger")
     })
   })
@@ -104,6 +110,10 @@ setup_dashboard_rendering <- function(input, output, session, project_data, i18n
       stats <- dashboard_stats()
       bs4ValueBox(stats$n_connections, i18n$t("ui.dashboard.connections"), icon = icon("arrow-right"), color = "success")
     }, error = function(e) {
+      showNotification(
+        format_user_error(e, i18n = i18n, context_key = "common.messages.context_dashboard_stats"),
+        type = "error", id = "dashboard_err_box2", session = session
+      )
       bs4ValueBox(0, i18n$t("ui.dashboard.error"), icon = icon("times"), color = "danger")
     })
   })
@@ -114,6 +124,10 @@ setup_dashboard_rendering <- function(input, output, session, project_data, i18n
       stats <- dashboard_stats()
       bs4ValueBox(stats$n_loops, i18n$t("ui.dashboard.loops_detected"), icon = icon("refresh"), color = "orange")
     }, error = function(e) {
+      showNotification(
+        format_user_error(e, i18n = i18n, context_key = "common.messages.context_dashboard_stats"),
+        type = "error", id = "dashboard_err_box3", session = session
+      )
       bs4ValueBox(0, i18n$t("ui.dashboard.error"), icon = icon("times"), color = "danger")
     })
   })
@@ -152,6 +166,10 @@ setup_dashboard_rendering <- function(input, output, session, project_data, i18n
         color = if(completion >= 75) "success" else if(completion >= 40) "warning" else "secondary"
       )
     }, error = function(e) {
+      showNotification(
+        format_user_error(e, i18n = i18n, context_key = "common.messages.context_dashboard_stats"),
+        type = "error", id = "dashboard_err_box4", session = session
+      )
       bs4ValueBox("0%", i18n$t("ui.dashboard.error"), icon = icon("times"), color = "danger")
     })
   })

--- a/MarineSABRES_SES_Shiny/server/language_handling.R
+++ b/MarineSABRES_SES_Shiny/server/language_handling.R
@@ -126,7 +126,15 @@ setup_language_restore_handler <- function(input, project_data, session_i18n) {
       }
     }, error = function(e) {
       debug_log(sprintf("ERROR restoring project data: %s", e$message), "LANG_RESTORE")
-      # Don't show error to user, just log it - the default template will be used
+      # Surface a translated notification so the user knows their in-progress
+      # work could not be restored after the language change (the default
+      # template is used as the fallback). Previously this failed silently.
+      shiny::showNotification(
+        format_user_error(e, i18n = session_i18n,
+                          context_key = "common.messages.context_language_change_restore"),
+        type = "error",
+        duration = 6
+      )
     })
   }, ignoreInit = TRUE)
 }

--- a/MarineSABRES_SES_Shiny/server/modals.R
+++ b/MarineSABRES_SES_Shiny/server/modals.R
@@ -104,7 +104,8 @@ setup_language_modal_only <- function(input, output, session, i18n, AVAILABLE_LA
     # IMPORTANT: Save project data to sessionStorage before reload to preserve user's work
     # This ensures SES creation progress is not lost during language changes
     if (!is.null(project_data)) {
-      tryCatch({
+      save_error <- NULL
+      save_success <- tryCatch({
         data <- project_data()
         if (!is.null(data)) {
           # Convert to JSON and send to JavaScript for sessionStorage
@@ -115,9 +116,26 @@ setup_language_modal_only <- function(input, output, session, i18n, AVAILABLE_LA
           )
           debug_log("Project data saved before language change reload", "LANGUAGE")
         }
+        TRUE
       }, error = function(e) {
         debug_log(paste("Could not save project data before reload:", e$message), "LANGUAGE")
+        save_error <<- e
+        FALSE
       })
+
+      # ABORT the reload if the save failed. MODAL_ANIMATION_DELAY_MS (100ms) is
+      # too short for the error toast to render before location.reload() fires,
+      # so reloading would both destroy the user's unsaved work AND the toast.
+      # Early-return keeps the notification on screen and the work intact.
+      if (!isTRUE(save_success)) {
+        showNotification(
+          format_user_error(save_error %||% simpleError("project data save failed"),
+                            i18n = i18n,
+                            context_key = "common.messages.context_language_change_save"),
+          type = "error", duration = NULL, session = session
+        )
+        return()
+      }
     }
 
     # Save language to localStorage and reload with URL parameter

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-dashboard.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-dashboard.R
@@ -1,0 +1,19 @@
+test_that("dashboard value-box error handlers reference context_dashboard_stats", {
+  expect_context_key_in_file(
+    "server/dashboard.R",
+    "context_dashboard_stats",
+    info = "All 4 dashboard value-box catches must surface format_user_error(context_key='common.messages.context_dashboard_stats')."
+  )
+})
+
+test_that("dashboard has 4 distinct per-box notification ids (one per value-box)", {
+  td <- getwd()
+  root <- if (basename(td) == "testthat") dirname(dirname(td)) else td
+  src <- paste(readLines(file.path(root, "server", "dashboard.R"),
+                         warn = FALSE), collapse = "\n")
+  matches <- gregexpr("dashboard_err_box[1-4]", src)[[1]]
+  expect_true(
+    length(matches) >= 4 && attr(matches, "match.length")[1] > 0,
+    info = "Must have id='dashboard_err_box1' through 'dashboard_err_box4' across the 4 value-box catches. Hardcoded per-box id — bounded to 4 toasts max, no hash collisions, no digest package dep."
+  )
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-language-handling.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-language-handling.R
@@ -1,0 +1,10 @@
+# tests/testthat/test-language-handling.R
+# Phase C Task 5 — language-change restore handler error surfacing
+
+test_that("language_handling.R post-reload restore handler surfaces translated user notification on failure", {
+  expect_context_key_in_file(
+    "server/language_handling.R",
+    "context_language_change_restore",
+    info = "Restore error handler in setup_language_restore_handler must surface format_user_error(context_key='common.messages.context_language_change_restore') using session_i18n (function parameter at line 95). Was explicitly silent ('Don't show error to user' comment)."
+  )
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-modals.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-modals.R
@@ -1,0 +1,17 @@
+# tests/testthat/test-modals.R
+# Phase C Task 5 — language-change save handler error surfacing
+
+test_that("modals.R language-change save handler aborts reload and surfaces a translated user notification on save failure", {
+  expect_context_key_in_file(
+    "server/modals.R",
+    "context_language_change_save",
+    info = "Save error handler in setup_language_modal_only must surface format_user_error(context_key='common.messages.context_language_change_save'). MODAL_ANIMATION_DELAY_MS=100ms is too short for toast render+reload, so the fix must also ABORT the reload (early return on save failure) so the notification persists."
+  )
+  td <- getwd()
+  root <- if (basename(td) == "testthat") dirname(dirname(td)) else td
+  src <- paste(readLines(file.path(root, "server", "modals.R"), warn = FALSE), collapse = "\n")
+  expect_true(
+    grepl("save_success\\s*<-\\s*tryCatch", src, perl = TRUE),
+    info = "Save handler must capture tryCatch result as save_success and early-return on FALSE — otherwise the reload destroys the notification before user can read it."
+  )
+})

--- a/MarineSABRES_SES_Shiny/translations/common/messages.json
+++ b/MarineSABRES_SES_Shiny/translations/common/messages.json
@@ -1133,6 +1133,39 @@
       "no": "gjenoppbygger forbindelsesmatrisen",
       "el": "ανοικοδόμηση του πίνακα συνδέσεων"
     },
+    "common.messages.context_dashboard_stats": {
+      "en": "loading dashboard statistics",
+      "es": "cargando estadísticas del panel",
+      "fr": "chargement des statistiques du tableau de bord",
+      "de": "Laden der Dashboard-Statistiken",
+      "lt": "įkeliama informacijos suvestinės statistika",
+      "pt": "carregando estatísticas do painel",
+      "it": "caricamento delle statistiche della dashboard",
+      "no": "laster inn dashbordstatistikk",
+      "el": "φόρτωση στατιστικών του πίνακα ελέγχου"
+    },
+    "common.messages.context_language_change_restore": {
+      "en": "restoring your work after the language change",
+      "es": "restaurando su trabajo después del cambio de idioma",
+      "fr": "restauration de votre travail après le changement de langue",
+      "de": "Wiederherstellung Ihrer Arbeit nach dem Sprachwechsel",
+      "lt": "atkuriamas jūsų darbas po kalbos pakeitimo",
+      "pt": "restaurando o seu trabalho após a mudança de idioma",
+      "it": "ripristino del tuo lavoro dopo il cambio di lingua",
+      "no": "gjenoppretter arbeidet ditt etter språkendringen",
+      "el": "επαναφορά της εργασίας σας μετά την αλλαγή γλώσσας"
+    },
+    "common.messages.context_language_change_save": {
+      "en": "saving your work before the language change",
+      "es": "guardando su trabajo antes del cambio de idioma",
+      "fr": "enregistrement de votre travail avant le changement de langue",
+      "de": "Speichern Ihrer Arbeit vor dem Sprachwechsel",
+      "lt": "išsaugomas jūsų darbas prieš kalbos pakeitimą",
+      "pt": "salvando o seu trabalho antes da mudança de idioma",
+      "it": "salvataggio del tuo lavoro prima del cambio di lingua",
+      "no": "lagrer arbeidet ditt før språkendringen",
+      "el": "αποθήκευση της εργασίας σας πριν από την αλλαγή γλώσσας"
+    },
     "common.messages.context_loading_project": {
       "en": "loading project",
       "es": "cargando proyecto",


### PR DESCRIPTION
@
Greens 5 of the 6 failing suite tests (the WIP source-grep specs in `test-dashboard`, `test-language-handling`, `test-modals`) by turning three **silent-failure** paths into translated user notifications via `format_user_error`:

- **`server/dashboard.R`** — all 4 value-box `tryCatch` catches now show a notification with a per-box id (`dashboard_err_box1..4`, so each is one replaceable toast, no collisions) and `context_key=common.messages.context_dashboard_stats`. Previously they returned a red box with no explanation.
- **`server/language_handling.R`** — `setup_language_restore_handler` was *explicitly silent* on restore failure ("Don't show error to user"); now surfaces `context_language_change_restore` via `session_i18n`, so a user whose work fails to restore after a language switch actually finds out.
- **`server/modals.R`** — `setup_language_modal_only` now captures `save_success` and **aborts the reload** (early return) on save failure, plus shows `context_language_change_save`. The `MODAL_ANIMATION_DELAY_MS` (100ms) reload was too fast for the toast to render, so a failed save used to destroy the user's work *and* the error message silently.

Adds the 3 `common.messages.context_*` keys ×9 languages. The 3 WIP test files are committed alongside (they were untracked in the tree). All three server files parse-checked.

**Not included:** `test-ml-ensemble.R` — its `<1s` bound times a 500-row stress batch and is genuinely unachievable on CPU-only hardware (even the min-of-5 steady-state exceeds 1s here); that one is a perf-threshold decision, left separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error notifications now display when dashboard value boxes fail to load, with distinct messages per box
  * Translated error messages appear when language change restore operations fail
  * Project data save failures during language change now prevent page reload and display error notifications

* **Tests**
  * Added test coverage for new error notification behaviors across dashboard and language change operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->