### PR TITLE
perf: literal substring match in create_element_embedding (~7.5x/call)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/ml_feature_engineering.R
+++ b/MarineSABRES_SES_Shiny/functions/ml_feature_engineering.R
@@ -348,8 +348,12 @@ create_element_embedding <- function(element_name, embedding_dim = 128) {
     if (any(words %in% MARINE_VOCABULARY[i])) {
       vocab_features[i] <- 1
     }
-    # Partial matching
-    if (any(grepl(MARINE_VOCABULARY[i], words))) {
+    # Partial (substring) matching. fixed = TRUE is value-identical here because
+    # MARINE_VOCABULARY entries are plain words with no regex metacharacters (a
+    # regex of a literal string == a literal substring match), but it skips PCRE
+    # compilation — the dominant cost of this embedding (grepl was ~40% of
+    # predict_batch_ml in profiling).
+    if (any(grepl(MARINE_VOCABULARY[i], words, fixed = TRUE))) {
       vocab_features[i] <- 0.5
     }
   }


### PR DESCRIPTION
## Profiling lead

`Rprof` of `predict_batch_ml` (after the memoization fix) showed `grepl` at **~40% of runtime** — the ~100 per-call regex matches in `create_element_embedding`'s vocabulary loop.

## Fix

`MARINE_VOCABULARY` entries are plain words with **no regex metacharacters**, so `grepl(vocab[i], words, fixed = TRUE)` is provably value-identical (a regex of a literal string is just a literal substring match) but skips PCRE compilation. Only the vocabulary loop is changed; the word-count-feature grepls (`"ing$"`, `"^over"`, `"a|b"`) use real regex and are left as-is.

## Verified value-identical (the model's input embeddings must not change)

- vocab features match the regex-computed reference across 12 realistic element names
- `test-ml-feature-engineering` (108 assertions) and `test-ml-inference` stay green

## Result

`create_element_embedding`: **32.8 ms -> 4.37 ms (~7.5x)**. This speeds up every ML feature that embeds element names (interactive single-element classification, ML-assisted ISA recommendations), not just batch prediction. Matters on laguna (CPU-only).

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced vocabulary-based feature generation with improved matching precision for more accurate feature identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->