### PR TITLE
feat: feedback resolution status + feedback-triage skill

### DIFF
--- a/MarineSABRES_SES_Shiny/.claude/skills/feedback-triage/SKILL.md
+++ b/MarineSABRES_SES_Shiny/.claude/skills/feedback-triage/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: feedback-triage
+description: Pull live user feedback from laguna, triage it, drive a checkpointed fix cycle per entry, and mark each entry addressed in the live log. Use when the user asks to triage/work the feedback backlog, check user-reported bugs/suggestions, or "address the feedback".
+---
+
+# Feedback Triage
+
+Work the live MarineSABRES user-feedback backlog end to end. Irreversible/destructive
+actions (the FIRST live-log write of a session, every merge, GitHub-issue close, and
+deploy) are ALWAYS user-gated — ask and wait, never proceed unprompted.
+
+## 0. Constants
+- Live log: `LOG=/srv/shiny-server/marinesabres/data/user_feedback_log.ndjson` on `razinka@laguna.ku.lt`.
+- Lockfile: `$LOG.lock`. Run ALL ssh from the Bash tool (PowerShell ssh hangs on stdin here).
+- Repo root one level up at the SESToolbox dir; app subdir `MarineSABRES_SES_Shiny/`.
+
+## 1. Pull + back up (verified, per-invocation)
+- `STAMP=$(date +%F-%H%M%S)-$$`
+- `ssh -n razinka@laguna.ku.lt "cp $LOG /tmp/feedback_backup_$STAMP.ndjson && wc -l $LOG /tmp/feedback_backup_$STAMP.ndjson"` — confirm the two line counts MATCH; if the backup step fails, STOP.
+- `ssh -n razinka@laguna.ku.lt "cat $LOG" > local_feedback.ndjson` — record `N = wc -l` (the line count you triage against; passed later as `expect_total_lines`).
+
+## 2. Triage
+- Parse each line; no `status` = OPEN; `duplicate_of` (≠ "NA"/"") ⇒ duplicate.
+- Reconcile: if (parsed entries) < (raw non-blank lines), some lines are malformed — list them as "needs manual triage", do not silently skip.
+- Keep OPEN `bug`/`suggestion`; detect duplicates by similar title; prioritize bugs.
+- Present a numbered list: line · type · title · one-line assessment. Large backlog → one read-only Agent per entry to classify, then proceed sequentially.
+
+## 3. Per entry (checkpointed)
+For each OPEN bug, in priority order:
+1. Reproduce + diagnose — invoke `superpowers:systematic-debugging`.
+2. Fix — invoke `superpowers:test-driven-development` (failing test → fix → green).
+3. Branch + commit + PR (`git -C "<SESToolbox root>"`, prefix paths with `MarineSABRES_SES_Shiny/`).
+4. **Ask the user to approve the merge.** Never merge unprompted.
+5. On merge → mark addressed (NEVER interpolate the note/title into a command; pass via a params file):
+   a. Write `params.json` LOCALLY: `{"log":"$LOG","match_title":"<exact title>","match_timestamp":"<exact timestamp>","status":"addressed","resolved_by":"feedback-triage","note":"<note>","fix_ref":"<PR/SHA>","expect_total_lines":N}` (encode with a JSON library / jq — do not hand-concatenate).
+   b. `scp params.json mark_resolved_remote.R razinka@laguna.ku.lt:/tmp/ && ssh -n razinka@laguna.ku.lt "flock $LOG.lock Rscript /tmp/mark_resolved_remote.R /tmp/params.json"` — chain with `&&`; CHECK THE ssh EXIT CODE (0 = success). Non-zero = STOP, report "mark FAILED" (do NOT record the entry as resolved).
+   c. Confirm: `ssh -n razinka@laguna.ku.lt "grep -F '<exact title>' $LOG"` and verify the line now has `"status":"addressed"`. If confirmation fails, report FAILED — never report addressed on an unverified write.
+   - If the marker prints `file grew` (a user submitted during triage), STOP, re-pull (1), recompute `N`, retry — prevents losing the user's new entry.
+For suggestions: assess; implement if small (same flow) else write a concrete proposal and ask before implementing.
+For duplicate / won't-fix / already-works: same params-file marker with that `status` + a note (no code change).
+If the entry has a `github_url` AND `MARINESABRES_GITHUB_TOKEN` is set: ask before `gh issue close` with a resolution comment. If the token is absent, SKIP (never prompt for/echo a token).
+
+## 4. Deploy gate
+After a batch of fixes is merged, surface the user-gated `git archive` deploy
+(`deployment/deploy-remote.ps1`, run via Bash with `< /dev/null`). After a verified
+deploy, re-run the params-file marker for each resolved entry with the SAME
+match_title/match_timestamp/status/fix_ref PLUS `"fix_deployed":"<laguna Version>"`
+(re-pull + fresh `expect_total_lines` first).
+
+## 5. Report
+Triaged N · fixed M (PR refs + statuses) · pending-deploy · malformed/needs-manual · deferred.
+
+## Safety
+- Never mark `addressed` before the fix is merged; treat the first live-log write as a gated checkpoint.
+- Skip entries already `addressed`/`duplicate`.
+- The marker matches by (title,timestamp) and aborts if the file grew — a concurrent user submission makes a mark FAIL (re-pull), never lose data.
+- Pass all free text via the params file — NEVER interpolate user/feedback text into an ssh command string.
+- Triage-only mode: do 2 and stop (no marking, no code).

--- a/MarineSABRES_SES_Shiny/.claude/skills/feedback-triage/mark_resolved_remote.R
+++ b/MarineSABRES_SES_Shiny/.claude/skills/feedback-triage/mark_resolved_remote.R
@@ -1,0 +1,37 @@
+# .claude/skills/feedback-triage/mark_resolved_remote.R
+# Rewrites ONE NDJSON entry's resolution fields atomically. Takes ONE arg: the
+# path to a JSON params file (so NO untrusted text touches a shell word).
+# Matches by (title,timestamp); aborts if the file grew (concurrent append) so
+# nothing is lost. Run UNDER flock. jsonlite only. Exit 0 = OK, 1 = fail.
+`%||%` <- function(a, b) if (is.null(a)) b else a
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 1L) { cat("ERR usage: <params.json>\n"); quit(status = 2) }
+ok <- tryCatch({
+  P <- jsonlite::fromJSON(args[1], simplifyVector = TRUE)
+  if (!P$status %in% c("open","addressed","wont_fix","duplicate")) stop("bad status")
+  log <- P$log
+  L <- readLines(log, warn = FALSE, encoding = "UTF-8")
+  if (!is.null(P$expect_total_lines) && length(L) != P$expect_total_lines)
+    stop(sprintf("file grew (%d != %d) - re-pull and retry", length(L), P$expect_total_lines))
+  idx <- which(vapply(L, function(ln) {
+    e <- tryCatch(jsonlite::fromJSON(trimws(ln), simplifyVector = TRUE), error = function(x) NULL)
+    !is.null(e) &&
+      identical(as.character(e$title), as.character(P$match_title)) &&
+      identical(as.character(e$timestamp %||% ""), as.character(P$match_timestamp %||% ""))
+  }, logical(1L)))
+  if (length(idx) != 1L) stop(sprintf("expected 1 (title,timestamp) match, found %d", length(idx)))
+  p <- jsonlite::fromJSON(trimws(L[[idx]]), simplifyVector = TRUE)
+  p$status          <- P$status
+  p$resolved_at     <- format(as.POSIXct(Sys.time(), tz = "UTC"), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+  p$resolved_by     <- P$resolved_by %||% "feedback-triage"
+  p$resolution_note <- P$note %||% ""
+  if (!is.null(P$fix_ref) && nzchar(P$fix_ref))           p$fix_ref      <- P$fix_ref
+  if (!is.null(P$fix_deployed) && nzchar(P$fix_deployed)) p$fix_deployed <- P$fix_deployed
+  L[[idx]] <- jsonlite::toJSON(p, auto_unbox = TRUE)
+  tmp <- paste0(log, ".tmp.", Sys.getpid())
+  on.exit(if (file.exists(tmp)) try(file.remove(tmp), silent = TRUE), add = TRUE)
+  writeLines(L, tmp, useBytes = TRUE)
+  if (!isTRUE(file.rename(tmp, log))) stop("rename failed")
+  cat(sprintf("OK matched line %d\n", idx)); TRUE
+}, error = function(e) { cat("ERR", conditionMessage(e), "\n"); FALSE })
+if (isTRUE(ok)) quit(status = 0) else { cat("FAIL\n"); quit(status = 1) }

--- a/MarineSABRES_SES_Shiny/functions/feedback_analyzer.R
+++ b/MarineSABRES_SES_Shiny/functions/feedback_analyzer.R
@@ -342,3 +342,85 @@ mark_as_duplicate <- function(log_path, line_num, duplicate_of_line) {
     FALSE
   })
 }
+
+# Allowed feedback resolution statuses. An entry with no `status` is treated as
+# "open" by load_feedback_log(); "duplicate" is set implicitly when duplicate_of
+# is present (handled in load_feedback_log).
+ALLOWED_FEEDBACK_STATUSES <- c("open", "addressed", "wont_fix", "duplicate")
+
+#' Mark a feedback entry resolved (atomic single-line rewrite)
+#'
+#' Mirrors mark_as_duplicate(): reads the file, parses the target line's JSON,
+#' sets the resolution fields, and atomically replaces the file. `now` is
+#' injectable for deterministic tests.
+#'
+#' @return TRUE on success, FALSE on any error / invalid status / bad line_num.
+mark_as_resolved <- function(log_path, line_num,
+                             status = "addressed",
+                             note = "",
+                             fix_ref = NA_character_,
+                             resolved_by = "admin",
+                             fix_deployed = NA_character_,
+                             now = NULL) {
+  tryCatch({
+    if (!status %in% ALLOWED_FEEDBACK_STATUSES) {
+      debug_log(paste("mark_as_resolved: invalid status", status), "ERROR")
+      return(FALSE)
+    }
+    if (!file.exists(log_path)) {
+      debug_log("mark_as_resolved: file not found", "ERROR")
+      return(FALSE)
+    }
+
+    raw_lines <- readLines(log_path, warn = FALSE, encoding = "UTF-8")
+
+    if (line_num < 1L || line_num > length(raw_lines)) {
+      debug_log(paste("mark_as_resolved: line_num", line_num,
+                      "out of range (1 -", length(raw_lines), ")"), "ERROR")
+      return(FALSE)
+    }
+
+    target_raw <- trimws(raw_lines[[line_num]])
+    if (nchar(target_raw) == 0L) {
+      debug_log(paste("mark_as_resolved: line", line_num, "is empty"), "ERROR")
+      return(FALSE)
+    }
+
+    parsed <- tryCatch(
+      jsonlite::fromJSON(target_raw, simplifyVector = TRUE),
+      error = function(e) NULL
+    )
+    if (is.null(parsed) || !is.list(parsed)) {
+      debug_log(paste("mark_as_resolved: line", line_num, "is not valid JSON"), "ERROR")
+      return(FALSE)
+    }
+
+    parsed$status          <- status
+    # UTC ...Z to match the existing `timestamp` field's format.
+    parsed$resolved_at     <- if (is.null(now)) format(as.POSIXct(Sys.time(), tz = "UTC"), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC") else now
+    parsed$resolved_by     <- as.character(resolved_by)
+    parsed$resolution_note <- as.character(note)
+    if (!is.na(fix_ref))      parsed$fix_ref      <- as.character(fix_ref)
+    if (!is.na(fix_deployed)) parsed$fix_deployed <- as.character(fix_deployed)
+
+    raw_lines[[line_num]] <- jsonlite::toJSON(parsed, auto_unbox = TRUE)
+
+    tmp_path <- paste0(log_path, ".tmp.", Sys.getpid())
+    # Clean up the temp file on ANY exit (write error, rename failure; success
+    # leaves no temp). Prevents leaked .tmp.<pid> files.
+    on.exit(if (file.exists(tmp_path)) try(file.remove(tmp_path), silent = TRUE), add = TRUE)
+    # useBytes=TRUE: lines are already UTF-8 from readLines(encoding="UTF-8");
+    # useBytes=FALSE could mojibake non-ASCII (Greek) in UNTOUCHED lines on a
+    # non-UTF-8 server locale.
+    writeLines(raw_lines, con = tmp_path, useBytes = TRUE)
+    rename_ok <- file.rename(tmp_path, log_path)
+    if (!isTRUE(rename_ok)) {
+      debug_log(paste("mark_as_resolved: file.rename failed for line", line_num), "ERROR")
+      return(FALSE)
+    }
+    TRUE
+  }, error = function(e) {
+    debug_log(paste("mark_as_resolved error:", e$message), "ERROR")
+    FALSE
+  })
+}

--- a/MarineSABRES_SES_Shiny/functions/feedback_analyzer.R
+++ b/MarineSABRES_SES_Shiny/functions/feedback_analyzer.R
@@ -38,6 +38,12 @@ load_feedback_log <- function(path = "data/user_feedback_log.ndjson") {
       timestamp    = character(0),
       github_url   = character(0),
       duplicate_of = character(0),
+      status          = character(0),
+      resolved_at     = character(0),
+      resolved_by     = character(0),
+      resolution_note = character(0),
+      fix_ref         = character(0),
+      fix_deployed    = character(0),
       stringsAsFactors = FALSE
     )
   }
@@ -58,6 +64,7 @@ load_feedback_log <- function(path = "data/user_feedback_log.ndjson") {
   if (length(raw_lines) == 0L) return(empty_df())
 
   rows <- list()
+  skipped <- integer(0)
 
   for (i in seq_along(raw_lines)) {
     line <- trimws(raw_lines[[i]])
@@ -70,6 +77,7 @@ load_feedback_log <- function(path = "data/user_feedback_log.ndjson") {
 
     if (is.null(parsed) || !is.list(parsed)) {
       debug_log(paste("load_feedback_log: skipping malformed line", i), "WARN")
+      skipped <- c(skipped, i)
       next
     }
 
@@ -81,7 +89,19 @@ load_feedback_log <- function(path = "data/user_feedback_log.ndjson") {
       steps        = as.character(parsed$steps        %||% NA_character_),
       timestamp    = as.character(parsed$timestamp    %||% NA_character_),
       github_url   = as.character(parsed$github_url   %||% NA_character_),
-      duplicate_of = as.character(parsed$duplicate_of %||% NA_character_)
+      duplicate_of = as.character(parsed$duplicate_of %||% NA_character_),
+      status = {
+        s <- parsed$status
+        if (length(s) == 1L && nzchar(as.character(s))) as.character(s)
+        else if (!is.null(parsed$duplicate_of) &&
+                 !as.character(parsed$duplicate_of) %in% c("NA", "")) "duplicate"
+        else "open"
+      },
+      resolved_at     = as.character(parsed$resolved_at     %||% NA_character_),
+      resolved_by     = as.character(parsed$resolved_by     %||% NA_character_),
+      resolution_note = as.character(parsed$resolution_note %||% NA_character_),
+      fix_ref         = as.character(parsed$fix_ref         %||% NA_character_),
+      fix_deployed    = as.character(parsed$fix_deployed    %||% NA_character_)
     )
     rows[[length(rows) + 1L]] <- row
   }
@@ -101,6 +121,7 @@ load_feedback_log <- function(path = "data/user_feedback_log.ndjson") {
   # Reset rownames
   rownames(df) <- NULL
 
+  attr(df, "skipped_lines") <- skipped
   df
 }
 

--- a/MarineSABRES_SES_Shiny/modules/feedback_admin_module.R
+++ b/MarineSABRES_SES_Shiny/modules/feedback_admin_module.R
@@ -53,6 +53,21 @@ feedback_admin_ui <- function(id, i18n) {
           ),
           column(2,
             bs4ValueBoxOutput(ns("vbox_local"), width = 12)
+          ),
+          column(2,
+            bs4ValueBoxOutput(ns("vbox_resolved"), width = 12)
+          )
+        ),
+
+        # Status filter
+        fluidRow(
+          column(3,
+            selectInput(
+              ns("status_filter"),
+              label = i18n$t("modules.feedback_admin.filter_status"),
+              choices = c("open", "resolved", "all"),
+              selected = "open"
+            )
           )
         ),
 
@@ -142,14 +157,18 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
     } else {
       "data/user_feedback_log.ndjson"
     }
+    # Testability seam: allow tests to point the module at a fixture file.
+    # Inert in production (option is unset).
+    log_path <- getOption("marinesabres.feedback_log_path", log_path)
 
     # ------------------------------------------------------------------
     # Reactive: feedback data (loaded once on session start, refreshable)
     # ------------------------------------------------------------------
     rv <- reactiveValues(
-      feedback_df   = NULL,
-      dup_pairs     = NULL,
-      selected_row  = NULL
+      feedback_df       = NULL,
+      dup_pairs         = NULL,
+      selected_row      = NULL,
+      pending_mark_line = NULL
     )
 
     # Load data once on session start
@@ -258,11 +277,37 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
       )
     })
 
+    output$vbox_resolved <- renderbs4ValueBox({
+      df <- rv$feedback_df
+      n  <- if (is.null(df) || !nrow(df)) 0L else sum(df$status != "open", na.rm = TRUE)
+      bs4ValueBox(
+        value    = n,
+        subtitle = i18n$t("modules.feedback_admin.resolved"),
+        icon     = tags$i(class = "fas fa-check-double"),
+        color    = "success",
+        width    = 12
+      )
+    })
+
+    # ------------------------------------------------------------------
+    # Filtered feedback (status filter applied). Exposed as a reactive so the
+    # DT render and tests share one source of truth (DT serializes row data
+    # out-of-band, so the rendered widget JSON can't be grepped for rows).
+    # ------------------------------------------------------------------
+    filtered_feedback <- reactive({
+      df <- rv$feedback_df
+      if (is.null(df) || nrow(df) == 0L) return(df)
+      sel_status <- input$status_filter %||% "open"
+      if (sel_status == "open")          df <- df[df$status == "open", , drop = FALSE]
+      else if (sel_status == "resolved") df <- df[df$status != "open", , drop = FALSE]
+      df
+    })
+
     # ------------------------------------------------------------------
     # Feedback DT table
     # ------------------------------------------------------------------
     output$feedback_table <- DT::renderDataTable({
-      df <- rv$feedback_df
+      df <- filtered_feedback()
 
       if (is.null(df) || nrow(df) == 0L) {
         return(DT::datatable(
@@ -284,6 +329,21 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
         '<i class="fa fa-times-circle text-muted"></i>'
       )
 
+      # Per-row "Mark addressed" button (open rows only). Carries the explicit
+      # line_num (NOT a DataTable row index) so it stays correct under filtering.
+      ns_mark <- ns("mark_addr_click")
+      action_html <- vapply(seq_len(nrow(df)), function(k) {
+        if (!is.na(df$status[k]) && df$status[k] == "open") {
+          sprintf(
+            '<button class="btn btn-xs btn-success" onclick="Shiny.setInputValue(\'%s\', {line: %d, rand: Math.random()})">%s</button>',
+            ns_mark, df$line_num[k],
+            htmltools::htmlEscape(i18n$t("modules.feedback_admin.mark_addressed"))
+          )
+        } else {
+          ""
+        }
+      }, character(1L))
+
       disp <- data.frame(
         Date        = format(suppressWarnings(
           as.POSIXct(df$timestamp, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC")),
@@ -295,7 +355,9 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
           paste0(substr(df$description, 1, 100), "\u2026"),
           df$description
         ),
+        Status      = df$status,
         GitHub      = github_html,
+        Action      = action_html,
         stringsAsFactors = FALSE
       )
 
@@ -306,7 +368,9 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
           i18n$t("modules.feedback_admin.col_type"),
           i18n$t("modules.feedback_admin.col_title"),
           i18n$t("modules.feedback_admin.col_description"),
-          i18n$t("modules.feedback_admin.col_github")
+          i18n$t("modules.feedback_admin.status"),
+          i18n$t("modules.feedback_admin.col_github"),
+          i18n$t("modules.feedback_admin.col_action")
         ),
         escape      = FALSE,
         selection   = "single",
@@ -317,7 +381,9 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
           dom        = "lfrtip",
           scrollX    = TRUE
         )
-      )
+      ) |> DT::formatStyle("Status", backgroundColor = DT::styleEqual(
+            c("open", "addressed", "wont_fix", "duplicate"),
+            c("#e9ecef", "#d4edda", "#e2e3e5", "#fff3cd")))
     })
 
     # ------------------------------------------------------------------
@@ -521,6 +587,62 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
       } else {
         showNotification(
           i18n$t("modules.feedback_admin.mark_error"),
+          type = "error"
+        )
+      }
+    }, ignoreInit = TRUE)
+
+    # ------------------------------------------------------------------
+    # Mark-as-addressed workflow (per-row button -> modal -> mark_as_resolved)
+    # Mirrors mark_dup: carries explicit line_num (filter-safe).
+    # ------------------------------------------------------------------
+    observeEvent(input$mark_addr_click, {
+      req(!is.null(input$mark_addr_click$line))
+      rv$pending_mark_line <- as.integer(input$mark_addr_click$line)
+      showModal(modalDialog(
+        title = i18n$t("modules.feedback_admin.mark_addressed"),
+        selectInput(session$ns("mark_addressed_status"),
+                    i18n$t("modules.feedback_admin.status"),
+                    choices = c("addressed", "wont_fix", "duplicate"),
+                    selected = "addressed"),
+        textAreaInput(session$ns("mark_addressed_note"),
+                      i18n$t("modules.feedback_admin.note")),
+        textInput(session$ns("mark_addressed_fix_ref"),
+                  i18n$t("modules.feedback_admin.fix_ref")),
+        footer = tagList(
+          modalButton(i18n$t("common.buttons.cancel")),
+          actionButton(session$ns("do_mark_addressed"),
+                       i18n$t("common.buttons.save"), class = "btn-success")
+        )
+      ))
+    }, ignoreInit = TRUE)
+
+    observeEvent(input$do_mark_addressed, {
+      ln <- rv$pending_mark_line
+      req(!is.null(ln))
+      ok <- tryCatch(
+        mark_as_resolved(
+          log_path, line_num = ln,
+          status      = input$mark_addressed_status %||% "addressed",
+          note        = input$mark_addressed_note %||% "",
+          fix_ref     = input$mark_addressed_fix_ref %||% NA_character_,
+          resolved_by = "admin"
+        ),
+        error = function(e) {
+          debug_log(paste("feedback_admin mark_addressed error:", e$message), "ERROR")
+          FALSE
+        }
+      )
+      removeModal()
+      if (isTRUE(ok)) {
+        rv$feedback_df <- load_feedback_log(log_path)
+        showNotification(
+          i18n$t("modules.feedback_admin.marked_addressed"),
+          type = "message"
+        )
+      } else {
+        showNotification(
+          i18n$t("modules.feedback_admin.mark_failed"),
           type = "error"
         )
       }

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-admin-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-admin-module.R
@@ -105,3 +105,54 @@ test_that("find_duplicates observer runs and the duplicates table renders", {
     expect_false(is.null(output$duplicates_table))
   })
 })
+
+# ============================================================================
+# RESOLUTION WORKFLOW TESTS (Task 3)
+# Mark-addressed flips status; status_filter changes the displayed set;
+# the Resolved value box renders. Uses the marinesabres.feedback_log_path
+# seam + the recalculate observer to force the gated load against a fixture.
+# ============================================================================
+
+test_that("mark-addressed flips status to addressed and refreshes", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines('{"title":"Bug A","type":"bug","timestamp":"t1"}', tmp)
+  withr::with_options(list(marinesabres.feedback_log_path = tmp), {
+    testServer(feedback_admin_server, args = list(i18n = i18n), {
+      session$setInputs(recalculate = 1); session$flushReact()
+      expect_false(is.null(output$vbox_total))         # proves fixture loaded
+      session$setInputs(mark_addr_click = list(line = 1, rand = 1))
+      session$setInputs(mark_addressed_status = "addressed",
+                        mark_addressed_note = "fixed in test",
+                        mark_addressed_fix_ref = "pr1")
+      session$setInputs(do_mark_addressed = 1); session$flushReact()
+      p <- jsonlite::fromJSON(readLines(tmp)[1])
+      expect_equal(p$status, "addressed"); expect_equal(p$fix_ref, "pr1")
+      expect_false(is.null(output$vbox_resolved))
+    })
+  })
+  unlink(tmp)
+})
+
+test_that("status_filter changes the displayed set", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines(c('{"title":"Open one","type":"bug","timestamp":"t1"}',
+               '{"title":"Done one","type":"bug","timestamp":"t2","status":"addressed"}'), tmp)
+  withr::with_options(list(marinesabres.feedback_log_path = tmp), {
+    testServer(feedback_admin_server, args = list(i18n = i18n), {
+      session$setInputs(recalculate = 1); session$flushReact()
+      # DT serializes row data out-of-band (server-side processing), so the
+      # rendered widget JSON cannot be grepped for row titles. Assert against
+      # the production `filtered_feedback()` reactive that the render consumes,
+      # and force the render so the reactive is exercised end-to-end.
+      session$setInputs(status_filter = "open"); session$flushReact()
+      invisible(output$feedback_table)
+      t1 <- filtered_feedback()$title
+      expect_true("Open one" %in% t1); expect_false("Done one" %in% t1)
+      session$setInputs(status_filter = "resolved"); session$flushReact()
+      invisible(output$feedback_table)
+      t2 <- filtered_feedback()$title
+      expect_true("Done one" %in% t2); expect_false("Open one" %in% t2)
+    })
+  })
+  unlink(tmp)
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-analyzer.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-analyzer.R
@@ -164,6 +164,30 @@ test_that("load_feedback_log defaults missing duplicate_of to NA_character_", {
   expect_true(is.na(df$duplicate_of[1L]))
 })
 
+test_that("load_feedback_log defaults missing status to open and surfaces resolution fields", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines(c(
+    '{"title":"A","type":"bug","timestamp":"t1"}',
+    '{"title":"B","type":"bug","timestamp":"t2","status":"addressed","fix_ref":"pr5"}',
+    '{"title":"C","type":"bug","timestamp":"t3","duplicate_of":"http://x"}'
+  ), tmp)
+  df <- load_feedback_log(tmp)
+  expect_true(all(c("status","resolved_at","resolved_by","resolution_note","fix_ref","fix_deployed") %in% names(df)))
+  expect_equal(df$status[df$title == "A"], "open")
+  expect_equal(df$status[df$title == "B"], "addressed")
+  expect_equal(df$fix_ref[df$title == "B"], "pr5")
+  expect_equal(df$status[df$title == "C"], "duplicate")   # implicit from duplicate_of
+  unlink(tmp)
+})
+
+test_that("load_feedback_log surfaces malformed lines via the skipped_lines attribute", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines(c('{"title":"A","type":"bug","timestamp":"t1"}', '{not valid json'), tmp)
+  df <- load_feedback_log(tmp)
+  expect_equal(attr(df, "skipped_lines"), 2L)
+  unlink(tmp)
+})
+
 
 # =============================================================================
 # compute_text_similarity tests

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-analyzer.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-analyzer.R
@@ -379,6 +379,84 @@ test_that("mark_as_duplicate returns FALSE for out-of-range line_num", {
 
 
 # =============================================================================
+# mark_as_resolved tests
+# =============================================================================
+
+test_that("mark_as_resolved sets status + resolution fields on the target line only", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines(c(
+    '{"title":"Bug A","type":"bug","description":"x"}',
+    '{"title":"Sug B","type":"suggestion","description":"y"}'
+  ), tmp)
+  ok <- mark_as_resolved(tmp, line_num = 1, status = "addressed",
+                         note = "fixed in PR", fix_ref = "abc123",
+                         resolved_by = "feedback-triage",
+                         now = "2026-05-31T00:00:00Z")
+  expect_true(ok)
+  lines <- readLines(tmp)
+  p1 <- jsonlite::fromJSON(lines[1]); p2 <- jsonlite::fromJSON(lines[2])
+  expect_equal(p1$status, "addressed")
+  expect_equal(p1$fix_ref, "abc123")
+  expect_equal(p1$resolved_by, "feedback-triage")
+  expect_equal(p1$resolution_note, "fixed in PR")
+  expect_equal(p1$resolved_at, "2026-05-31T00:00:00Z")
+  expect_null(p2$status)
+  expect_equal(p2$title, "Sug B")
+  unlink(tmp)
+})
+
+test_that("mark_as_resolved rejects invalid status and out-of-range line_num", {
+  tmp <- tempfile(fileext = ".ndjson"); writeLines('{"title":"A"}', tmp)
+  expect_false(mark_as_resolved(tmp, 1, status = "bogus"))
+  expect_false(mark_as_resolved(tmp, 5, status = "addressed"))
+  expect_false(mark_as_resolved(tmp, 0, status = "addressed"))
+  unlink(tmp)
+})
+
+test_that("mark_as_resolved is idempotent and keeps the file valid", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines(c('{"title":"A","type":"bug"}', '{"title":"B"}'), tmp)
+  mark_as_resolved(tmp, 1, status = "addressed", fix_ref = "r1", now = "t1")
+  mark_as_resolved(tmp, 1, status = "addressed", fix_ref = "r2", now = "t2")
+  lines <- readLines(tmp)
+  expect_length(lines, 2)
+  expect_equal(jsonlite::fromJSON(lines[1])$fix_ref, "r2")
+  expect_equal(jsonlite::fromJSON(lines[2])$title, "B")
+  unlink(tmp)
+})
+
+test_that("mark_as_resolved leaves other lines byte-identical", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines(c('{"title":"A","type":"bug"}', '{"title":"B","type":"bug"}'), tmp)
+  orig <- readLines(tmp)
+  mark_as_resolved(tmp, 1, status = "addressed", now = "t1")
+  expect_identical(readLines(tmp)[2], orig[2])   # untouched line unchanged
+  unlink(tmp)
+})
+
+test_that("mark_as_resolved returns FALSE on a malformed or blank target line and leaves the file unchanged", {
+  tmp <- tempfile(fileext = ".ndjson")
+  writeLines(c('{not json', ''), tmp)
+  orig <- readLines(tmp)
+  expect_false(mark_as_resolved(tmp, 1, status = "addressed"))  # malformed
+  expect_false(mark_as_resolved(tmp, 2, status = "addressed"))  # blank
+  expect_identical(readLines(tmp), orig)
+  unlink(tmp)
+})
+
+test_that("mark_as_resolved round-trips UTF-8 note and fix_deployed", {
+  tmp <- tempfile(fileext = ".ndjson"); writeLines('{"title":"A","type":"bug"}', tmp)
+  ok <- mark_as_resolved(tmp, 1, status = "addressed",
+                         note = "διορθώθηκε", fix_deployed = "1.16.5", now = "t1")
+  expect_true(ok)
+  p <- jsonlite::fromJSON(readLines(tmp)[1])
+  expect_equal(p$resolution_note, "διορθώθηκε")
+  expect_equal(p$fix_deployed, "1.16.5")
+  unlink(tmp)
+})
+
+
+# =============================================================================
 # feedback_admin_module tests
 # =============================================================================
 

--- a/MarineSABRES_SES_Shiny/translations/modules/feedback_admin.json
+++ b/MarineSABRES_SES_Shiny/translations/modules/feedback_admin.json
@@ -362,6 +362,94 @@
       "it": "Fatto",
       "no": "Ferdig",
       "el": "Ολοκληρώθηκε"
+    },
+    "modules.feedback_admin.resolved": {
+      "en": "Resolved",
+      "es": "Resueltos",
+      "fr": "Résolus",
+      "de": "Erledigt",
+      "lt": "Išspręsta",
+      "pt": "Resolvidos",
+      "it": "Risolti",
+      "no": "Løst",
+      "el": "Επιλύθηκαν"
+    },
+    "modules.feedback_admin.filter_status": {
+      "en": "Status filter",
+      "es": "Filtro de estado",
+      "fr": "Filtre de statut",
+      "de": "Statusfilter",
+      "lt": "Būsenos filtras",
+      "pt": "Filtro de estado",
+      "it": "Filtro stato",
+      "no": "Statusfilter",
+      "el": "Φίλτρο κατάστασης"
+    },
+    "modules.feedback_admin.status": {
+      "en": "Status",
+      "es": "Estado",
+      "fr": "Statut",
+      "de": "Status",
+      "lt": "Būsena",
+      "pt": "Estado",
+      "it": "Stato",
+      "no": "Status",
+      "el": "Κατάσταση"
+    },
+    "modules.feedback_admin.mark_addressed": {
+      "en": "Mark addressed",
+      "es": "Marcar como atendido",
+      "fr": "Marquer comme traité",
+      "de": "Als bearbeitet markieren",
+      "lt": "Žymėti kaip išspręstą",
+      "pt": "Marcar como tratado",
+      "it": "Segna come gestito",
+      "no": "Merk som behandlet",
+      "el": "Σήμανση ως αντιμετωπισμένο"
+    },
+    "modules.feedback_admin.note": {
+      "en": "Resolution note",
+      "es": "Nota de resolución",
+      "fr": "Note de résolution",
+      "de": "Lösungsnotiz",
+      "lt": "Sprendimo pastaba",
+      "pt": "Nota de resolução",
+      "it": "Nota di risoluzione",
+      "no": "Løsningsnotat",
+      "el": "Σημείωση επίλυσης"
+    },
+    "modules.feedback_admin.fix_ref": {
+      "en": "Fix reference (commit/PR)",
+      "es": "Referencia de corrección (commit/PR)",
+      "fr": "Référence du correctif (commit/PR)",
+      "de": "Fix-Referenz (Commit/PR)",
+      "lt": "Pataisos nuoroda (commit/PR)",
+      "pt": "Referência da correção (commit/PR)",
+      "it": "Riferimento correzione (commit/PR)",
+      "no": "Fiksreferanse (commit/PR)",
+      "el": "Αναφορά διόρθωσης (commit/PR)"
+    },
+    "modules.feedback_admin.marked_addressed": {
+      "en": "Feedback marked addressed.",
+      "es": "Comentario marcado como atendido.",
+      "fr": "Retour marqué comme traité.",
+      "de": "Feedback als bearbeitet markiert.",
+      "lt": "Atsiliepimas pažymėtas kaip išspręstas.",
+      "pt": "Comentário marcado como tratado.",
+      "it": "Feedback contrassegnato come gestito.",
+      "no": "Tilbakemelding merket som behandlet.",
+      "el": "Το σχόλιο σημάνθηκε ως αντιμετωπισμένο."
+    },
+    "modules.feedback_admin.mark_failed": {
+      "en": "Could not update the feedback entry.",
+      "es": "No se pudo actualizar la entrada de comentarios.",
+      "fr": "Impossible de mettre à jour l'entrée de retour.",
+      "de": "Der Feedback-Eintrag konnte nicht aktualisiert werden.",
+      "lt": "Nepavyko atnaujinti atsiliepimo įrašo.",
+      "pt": "Não foi possível atualizar a entrada de comentário.",
+      "it": "Impossibile aggiornare la voce di feedback.",
+      "no": "Kunne ikke oppdatere tilbakemeldingsoppføringen.",
+      "el": "Δεν ήταν δυνατή η ενημέρωση της καταχώρισης σχολίου."
     }
   }
 }


### PR DESCRIPTION
## What & why

The app already lets users **report** bugs/suggestions (feedback modal → `submit_feedback` → NDJSON + optional GitHub issue), but there was no way to mark an entry **addressed** and no tooling to work the backlog. This adds both:

**Part A — in-app resolution capability**
- `mark_as_resolved()` in `functions/feedback_analyzer.R` — atomic single-line rewrite (mirrors `mark_as_duplicate`), status validation, UTF-8 safe (`useBytes=TRUE`), idempotent, `on.exit` temp cleanup.
- `load_feedback_log()` now surfaces a `status` column (absent → `open`; `duplicate_of` → `duplicate`) + resolution fields + an `attr(,"skipped_lines")` so malformed lines aren't silently dropped.
- `feedback_admin_module.R` — a **Resolved** value box, an **open/resolved/all status filter**, a colour **status badge**, and a per-row **"Mark addressed"** button → modal → `mark_as_resolved` → refresh. The button carries the **explicit `line_num`** (mirrors the `mark_dup` pattern) so the filter can't desync the selection. 8 new i18n keys ×9 languages.

**Part B — `feedback-triage` skill** (`.claude/skills/feedback-triage/`)
- `SKILL.md` pulls the live laguna log, triages, drives a checkpointed fix cycle (debugging + TDD per entry), and marks entries addressed — with **merge / GitHub-close / deploy always user-gated**.
- `mark_resolved_remote.R` marks an entry on the server via a **single JSON params file** (no shell interpolation of user text → no injection), **matches by (title,timestamp)**, **aborts if the file grew** (concurrent user submission → fails loudly, never clobbers), and signals via **exit code**.

## Backward-compatible
The existing 5 live entries have no `status` and read as `open` — no migration.

## Process & verification
- Spec brainstormed → written → **reviewed by 5 parallel agents** (found 6 blockers — phantom reactive, shell-injection, lost-update race, filter/index desync, silent failures, test gaps — all fixed in the plan before implementation).
- Implemented task-by-task (TDD), each verified red→green.
- **Full test suite: 7302 passing, 0 failures, 0 regressions.** Remote marker smoke-tested (valid→OK, grow-guard→abort, non-match→fail).
- Final full-diff review: **ship** (only minor polish: a trailing newline; status-cell text not i18n'd — a justified `styleEqual` trade-off).

## Follow-up (out of scope, noted)
The feedback table renders raw user `title`/`description` with `escape = FALSE` (a **pre-existing** stored-XSS exposure, unchanged by this branch) — worth a separate hardening ticket.

Ships to laguna on the next (user-gated) deploy, where `mark_as_resolved` + the admin controls become live.

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feedback items can now be marked as resolved with configurable status, notes, and fix references
  * Status filtering available to organize feedback by resolution state
  * Resolution metadata (timestamp, reviewer, fix details) is now tracked and displayed

* **Documentation**
  * Added operational guide for feedback triage workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->