### PR TITLE
fix: load projects with lowercase 'id' / legacy structure (feedback: No elements)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/data_structure.R
+++ b/MarineSABRES_SES_Shiny/functions/data_structure.R
@@ -60,11 +60,31 @@ generate_stable_element_id <- function(prefix, store = .stable_id_counters) {
 #' @return list(df = repaired data.frame, repaired = logical scalar)
 reconcile_loaded_element_ids <- function(element_df, prefix, store = .stable_id_counters) {
   if (is.null(element_df) || !nrow(element_df)) return(list(df = element_df, repaired = FALSE))
-  ids <- as.character(element_df$ID)
+
+  # Detect the id column case-insensitively. Legacy/fork/JSON-origin/re-saved
+  # projects can carry a lowercase `id` (normalize_json_project_data lowercases
+  # all element columns). Rename it to canonical uppercase `ID` so the caller's
+  # `as.character(rec$df$ID)` is non-empty. If NO id column exists at all, treat
+  # every row as needing a fresh stable id.
+  repaired_structure <- FALSE
+  id_col <- names(element_df)[match("id", tolower(names(element_df)))]
+  if (!is.null(id_col) && !is.na(id_col)) {
+    if (id_col != "ID") {
+      names(element_df)[names(element_df) == id_col] <- "ID"
+      repaired_structure <- TRUE
+    }
+    ids <- as.character(element_df$ID)
+  } else {
+    # No id column present — every row is "bad" and needs an id.
+    ids <- rep(NA_character_, nrow(element_df))
+    repaired_structure <- TRUE
+  }
+
   bad <- duplicated(ids) | is.na(ids) | !nzchar(ids)
   if (!any(bad)) {
     seed_stable_id_counter(prefix, ids, store)
-    return(list(df = element_df, repaired = FALSE))
+    element_df$ID <- ids
+    return(list(df = element_df, repaired = repaired_structure))
   }
   seed_stable_id_counter(prefix, ids[!bad], store)
   for (k in which(bad)) ids[k] <- generate_stable_element_id(prefix, store)

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -292,12 +292,17 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
           drivers            = list(prefix = ELEMENT_ID_PREFIX$drivers,    panel = "d_panel_ids")
         )
         any_repaired <- FALSE
+        any_rows_in <- FALSE
+        any_panel_ids_out <- FALSE
         for (key in names(id_load_map)) {
           saved_df <- saved_isa[[key]]
           if (is.data.frame(saved_df) && nrow(saved_df) > 0) {
+            any_rows_in <- TRUE
             rec <- reconcile_loaded_element_ids(saved_df, id_load_map[[key]]$prefix, id_store)
             isa_data[[key]] <- rec$df
-            isa_data[[id_load_map[[key]]$panel]] <- as.character(rec$df$ID)
+            panel_ids <- as.character(rec$df$ID)
+            isa_data[[id_load_map[[key]]$panel]] <- panel_ids
+            if (length(panel_ids) > 0 && any(nzchar(panel_ids))) any_panel_ids_out <- TRUE
             if (isTRUE(rec$repaired)) any_repaired <- TRUE
           } else {
             isa_data[[id_load_map[[key]]$panel]] <- character(0)
@@ -306,6 +311,12 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
         if (any_repaired) {
           showNotification(i18n$t("modules.isa.data_entry.common.ids_repaired_on_load"),
                            type = "warning", duration = 8, session = session)
+        }
+        # Surface the previously-silent failure: rows came in but nothing
+        # resolved to a panel id (e.g. an unrecognized legacy structure).
+        if (any_rows_in && !any_panel_ids_out) {
+          showNotification(i18n$t("modules.isa.data_entry.common.no_elements_loaded"),
+                           type = "warning", duration = 10, session = session)
         }
 
         data_initialized(TRUE)

--- a/MarineSABRES_SES_Shiny/server/project_io.R
+++ b/MarineSABRES_SES_Shiny/server/project_io.R
@@ -105,8 +105,14 @@ setup_project_io_handlers <- function(input, output, session, project_data, i18n
         # Normalize uppercase column names and list structures to internal format
         if (!is.null(parsed)) normalize_json_project_data(parsed) else NULL
       } else {
-        # Load RDS file safely with size and type validation
-        safe_readRDS(file_path, max_size_mb = 50)
+        # Load RDS file safely with size and type validation, then normalize
+        # the same way JSON loads are: legacy/fork/re-saved RDS projects can
+        # carry uppercase element columns or list-shaped element types, and
+        # normalize_json_project_data lowercases columns + coerces list->df.
+        # Combined with the case-insensitive reconcile_loaded_element_ids this
+        # lets older projects load with their elements intact.
+        rds_data <- safe_readRDS(file_path, max_size_mb = 50)
+        if (!is.null(rds_data)) normalize_json_project_data(rds_data) else NULL
       }
 
       if (is.null(loaded_data)) {

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-matrix-from-linked.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-matrix-from-linked.R
@@ -74,3 +74,20 @@ test_that("reconcile_loaded_element_ids is a no-op for clean ids", {
   expect_equal(res$df$ID, c("ES001", "ES002"))
   expect_false(isTRUE(res$repaired))
 })
+
+test_that("reconcile_loaded_element_ids handles a lowercase 'id' column (load-path bug L6)", {
+  reset_stable_id_counter("ES")
+  df <- data.frame(id = c("ES001","ES002"), name = c("a","b"), stringsAsFactors = FALSE)
+  res <- reconcile_loaded_element_ids(df, "ES")
+  expect_true("ID" %in% names(res$df))
+  expect_equal(as.character(res$df$ID), c("ES001","ES002"))   # NON-empty -> panel_ids will populate
+})
+
+test_that("reconcile_loaded_element_ids generates ids when no id column exists", {
+  reset_stable_id_counter("GB")
+  df <- data.frame(name = c("x","y","z"), stringsAsFactors = FALSE)
+  res <- reconcile_loaded_element_ids(df, "GB")
+  expect_true("ID" %in% names(res$df))
+  expect_equal(sum(nzchar(as.character(res$df$ID))), 3L)       # all rows got an id
+  expect_equal(anyDuplicated(res$df$ID), 0)
+})

--- a/MarineSABRES_SES_Shiny/translations/modules/isa_data_entry.json
+++ b/MarineSABRES_SES_Shiny/translations/modules/isa_data_entry.json
@@ -44,6 +44,17 @@
       "no": "Noen element-ID-er ble reparert ved innlasting (duplikater fra en eldre versjon).",
       "el": "Ορισμένα αναγνωριστικά στοιχείων επιδιορθώθηκαν κατά τη φόρτωση (διπλότυπα από παλαιότερη έκδοση)."
     },
+    "modules.isa.data_entry.common.no_elements_loaded": {
+      "en": "This project loaded with no readable elements — it may be from an older version.",
+      "es": "Este proyecto se cargó sin elementos legibles; puede ser de una versión anterior.",
+      "fr": "Ce projet a été chargé sans éléments lisibles — il provient peut-être d'une version antérieure.",
+      "de": "Dieses Projekt wurde ohne lesbare Elemente geladen — es stammt möglicherweise aus einer älteren Version.",
+      "lt": "Šis projektas įkeltas be perskaitomų elementų — jis gali būti iš senesnės versijos.",
+      "pt": "Este projeto foi carregado sem elementos legíveis — pode ser de uma versão anterior.",
+      "it": "Questo progetto è stato caricato senza elementi leggibili — potrebbe provenire da una versione precedente.",
+      "no": "Dette prosjektet ble lastet inn uten lesbare elementer — det kan være fra en eldre versjon.",
+      "el": "Αυτό το έργο φορτώθηκε χωρίς αναγνώσιμα στοιχεία — μπορεί να προέρχεται από παλαιότερη έκδοση."
+    },
     "modules.isa.ai_assistant.eu_member_states": {
       "en": "EU Member States",
       "es": "Estados miembros de la UE",


### PR DESCRIPTION
## User feedback (laguna, v1.16.5)

> "No elements" — "When uploaded the RDS file, with entries in Standard Entry, no elements are shown."

## Root cause (diagnosed + test-confirmed)

`reconcile_loaded_element_ids()` read `element_df$ID` (uppercase only). The ISA-data-entry load observer then derives `*_panel_ids <- as.character(rec$df$ID)`. When a loaded project's element data.frames carry **lowercase `id`** (legacy/fork/JSON-origin/re-saved projects — and `normalize_json_project_data` lowercases columns), `$ID` is `NULL` → `*_panel_ids` becomes `character(0)` → the Standard Entry view shows **no elements, silently**.

Contributing silent-failure points: the RDS load path skipped the normalization the JSON path applies, and `validate_project_structure` doesn't check `isa_data` shape — so a mismatched project loads with no warning.

Confirmed with a minimal test: `reconcile_loaded_element_ids(data.frame(id="ES001"), "ES")` produced empty ids; `data.frame(ID="ES001")` produced `ES001`.

## Fix (TDD, 3 parts)

1. **`functions/data_structure.R`** — `reconcile_loaded_element_ids` detects the id column **case-insensitively** (`id`/`ID`), renames to canonical `ID`, and generates fresh stable ids when no id column exists. Output always has a populated `ID` → `panel_ids` populate.
2. **`server/project_io.R`** — RDS loads now go through `normalize_json_project_data` like JSON loads (consistent structure).
3. **`modules/isa_data_entry_module.R`** — if a loaded project had element rows but **zero** panel-ids resolved, show a warning ("loaded with no readable elements — may be from an older version") instead of a silently-empty view. New i18n key ×9 languages.

## Tests

- New reconcile tests (lowercase `id`; no-id-column → generate): red `[FAIL 4]` → green `[PASS 20]`.
- No regressions: isa-data-entry, stable-element-ids, **json-project-loading (1133)**, and the **full suite: 7307 passing, 0 failures**.

Addresses the live feedback entry "No elements" (timestamp 2026-06-01). Ships on the next (user-gated) deploy.

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced compatibility for legacy project files with improved ID detection and repair.
  * Ensured RDS and JSON project files load with consistent data formatting.
  * Added user notifications when project elements cannot be properly loaded.

* **Tests**
  * Added element ID reconciliation test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->