### PR TITLE
feat: Standard Entry Excel round-trip import (fixes L5)

### DIFF
--- a/MarineSABRES_SES_Shiny/app.R
+++ b/MarineSABRES_SES_Shiny/app.R
@@ -1034,7 +1034,7 @@ server <- function(input, output, session) {
   ai_isa_assistant_server("ai_isa_mod", project_data, session_i18n, event_bus, autosave_enabled, user_level, session, beginner_max_elements)
 
   # ISA data entry module (Standard Entry)
-  isa_data <- isa_data_entry_server("isa_module", project_data, session_i18n, event_bus)
+  isa_data <- isa_data_entry_server("isa_module", project_data, session_i18n, event_bus, parent_session = session)
 
   # Graphical SES Creator module (AI-powered step-by-step network building)
   graphical_ses_creator_server("graphical_ses_mod", project_data, session_i18n, session)

--- a/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
+++ b/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
@@ -72,6 +72,9 @@ read_standard_entry_workbook <- function(path) {
     stop(e)
   }
 
+  # NOTE: Case_Info / loop_connections sheets are not imported (out of L5 scope:
+  # elements + adjacency edges only). gb_d closing-loop survives via Matrix_gb_d.
+
   # Optional pass-through sheets
   if ("BOT_Data" %in% sheets) {
     bot <- openxlsx::read.xlsx(path, sheet = "BOT_Data")

--- a/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
+++ b/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
@@ -13,6 +13,11 @@
   Drivers            = "drivers"
 )
 
+# Returns TRUE when a data frame has the required Standard-Entry columns.
+.se_qualifies <- function(df) {
+  is.data.frame(df) && all(c("ID", "Name") %in% names(df))
+}
+
 #' Read a Standard-Entry-exported .xlsx into an isa_data-shaped list.
 #' @param path path to an .xlsx file written by write_isa_element_sheets().
 #' @return list with the six element data frames (all columns character),
@@ -50,6 +55,21 @@ read_standard_entry_workbook <- function(path) {
       am[[key]] <- mat
     }
     out$adjacency_matrices <- am
+  }
+
+  # Format detection: at least one element sheet must have ID+Name columns,
+  # OR at least one Matrix_* sheet must be present.
+  has_qualified_elements <- any(vapply(
+    .SE_ELEMENT_SHEETS,
+    function(key) .se_qualifies(out[[key]]),
+    logical(1)
+  ))
+  has_matrices <- !is.null(out$adjacency_matrices) && length(out$adjacency_matrices) > 0
+
+  if (!has_qualified_elements && !has_matrices) {
+    e <- simpleError("Not a Standard Entry export (no recognizable element or Matrix_* sheets).")
+    class(e) <- c("se_import_not_recognized", class(e))
+    stop(e)
   }
 
   # Optional pass-through sheets

--- a/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
+++ b/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
@@ -45,6 +45,7 @@ read_standard_entry_workbook <- function(path) {
       m <- openxlsx::read.xlsx(path, sheet = sheet, rowNames = TRUE)
       mat <- as.matrix(m)
       storage.mode(mat) <- "character"
+      # NA replacement must follow the character coercion above (numeric NA -> NA_character_, never the string "NA")
       mat[is.na(mat)] <- ""            # in-app empty-cell convention
       am[[key]] <- mat
     }

--- a/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
+++ b/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
@@ -1,0 +1,61 @@
+# functions/standard_entry_excel_import.R
+# Reader for the Standard Entry Excel export (per-category element sheets +
+# Matrix_* adjacency sheets, as written by write_isa_element_sheets()).
+# Returns a list shaped like project$data$isa_data. Pure / non-reactive.
+
+# Sheet name -> isa_data element key
+.SE_ELEMENT_SHEETS <- c(
+  Goods_Benefits     = "goods_benefits",
+  Ecosystem_Services = "ecosystem_services",
+  Marine_Processes   = "marine_processes",
+  Pressures          = "pressures",
+  Activities         = "activities",
+  Drivers            = "drivers"
+)
+
+#' Read a Standard-Entry-exported .xlsx into an isa_data-shaped list.
+#' @param path path to an .xlsx file written by write_isa_element_sheets().
+#' @return list with the six element data frames (all columns character),
+#'   adjacency_matrices (from Matrix_* sheets), and bot_data when present.
+read_standard_entry_workbook <- function(path) {
+  if (!is.character(path) || length(path) != 1L || !file.exists(path)) {
+    stop("read_standard_entry_workbook: file not found")
+  }
+  sheets <- openxlsx::getSheetNames(path)
+
+  out <- list()
+
+  # Element sheets -> character data frames
+  for (sheet in names(.SE_ELEMENT_SHEETS)) {
+    if (sheet %in% sheets) {
+      df <- openxlsx::read.xlsx(path, sheet = sheet)
+      if (is.null(df)) df <- data.frame()
+      df <- as.data.frame(df, stringsAsFactors = FALSE)
+      if (ncol(df) > 0) df[] <- lapply(df, as.character)
+      out[[.SE_ELEMENT_SHEETS[[sheet]]]] <- df
+    }
+  }
+
+  # Matrix_* sheets -> adjacency_matrices (faithful edges)
+  matrix_sheets <- sheets[startsWith(sheets, "Matrix_")]
+  if (length(matrix_sheets) > 0) {
+    am <- list()
+    for (sheet in matrix_sheets) {
+      key <- sub("^Matrix_", "", sheet)
+      m <- openxlsx::read.xlsx(path, sheet = sheet, rowNames = TRUE)
+      mat <- as.matrix(m)
+      storage.mode(mat) <- "character"
+      mat[is.na(mat)] <- ""            # in-app empty-cell convention
+      am[[key]] <- mat
+    }
+    out$adjacency_matrices <- am
+  }
+
+  # Optional pass-through sheets
+  if ("BOT_Data" %in% sheets) {
+    bot <- openxlsx::read.xlsx(path, sheet = "BOT_Data")
+    if (!is.null(bot)) out$bot_data <- as.data.frame(bot, stringsAsFactors = FALSE)
+  }
+
+  out
+}

--- a/MarineSABRES_SES_Shiny/global.R
+++ b/MarineSABRES_SES_Shiny/global.R
@@ -597,6 +597,9 @@ source("functions/data_structure.R", local = TRUE)
 # collectors call linked_select_to_ids/serialize_linked).
 source("functions/matrix_from_linked.R", local = TRUE)
 
+# Standard Entry Excel import — reader for Matrix_* sheet round-trips
+source("functions/standard_entry_excel_import.R", local = FALSE)  # FALSE = global scope for test/server access
+
 # ISA form builders and entry collection helpers (extracted from isa_data_entry_module)
 source("functions/isa_form_builders.R", local = TRUE)
 

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -1531,7 +1531,7 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
                             function(k) if (is.data.frame(isa_data[[k]])) nrow(isa_data[[k]]) else 0L,
                             integer(1)))
       n_edges <- sum(vapply(isa_data$adjacency_matrices,
-                            function(m) if (is.matrix(m)) sum(nzchar(m), na.rm = TRUE) else 0L,
+                            function(m) if (is.matrix(m)) sum(nzchar(m) & !is.na(m)) else 0L,
                             integer(1)))
 
       if (n_elems == 0L) {

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -301,6 +301,36 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
           isa_data[[id_load_map[[key]]$panel]] <- character(0)
         }
       }
+      # Fallback: if no adjacency_matrices were supplied (e.g. an export without
+      # Matrix_* sheets), rebuild the five forward transitions from the per-category
+      # Linked* columns at default +/Medium. gb_d (closing loop) is NOT recoverable
+      # this way. Caller shows a notice when fell_back is TRUE.
+      fell_back <- FALSE
+      if (is.null(isa_data$adjacency_matrices) || length(isa_data$adjacency_matrices) == 0) {
+        linked_map <- list(
+          es_gb  = list(src = "ecosystem_services", col = "LinkedGB",  tgt = "goods_benefits"),
+          mpf_es = list(src = "marine_processes",   col = "LinkedES",  tgt = "ecosystem_services"),
+          p_mpf  = list(src = "pressures",          col = "LinkedMPF", tgt = "marine_processes"),
+          a_p    = list(src = "activities",         col = "LinkedP",   tgt = "pressures"),
+          d_a    = list(src = "drivers",            col = "LinkedA",   tgt = "activities")
+        )
+        for (mk in names(linked_map)) {
+          m <- linked_map[[mk]]
+          src_df <- isa_data[[m$src]]
+          tgt_df <- isa_data[[m$tgt]]
+          if (is.data.frame(src_df) && nrow(src_df) > 0 && m$col %in% names(src_df) &&
+              is.data.frame(tgt_df) && nrow(tgt_df) > 0) {
+            rb <- rebuild_matrix_from_linked(
+              element_df = src_df, linked_col = m$col,
+              source_ids = as.character(src_df$ID), target_ids = as.character(tgt_df$ID),
+              element_confidence_col = "Confidence")
+            isa_data$adjacency_matrices[[mk]] <- rb$matrix
+            isa_data$user_edited_matrices[[mk]] <- rb$user_edited
+            fell_back <- TRUE
+          }
+        }
+      }
+
       if (any_repaired) {
         showNotification(i18n$t("modules.isa.data_entry.common.ids_repaired_on_load"),
                          type = "warning", duration = 8, session = session)
@@ -309,7 +339,7 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
         showNotification(i18n$t("modules.isa.data_entry.common.no_elements_loaded"),
                          type = "warning", duration = 10, session = session)
       }
-      invisible(NULL)
+      invisible(list(fell_back = fell_back))
     }
 
     # Load saved ISA data when a (different) project becomes active. Keyed on

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -41,7 +41,7 @@ isa_data_entry_ui <- function(id, i18n) {
 
 # Module Server ----
 # Standardized signature: (id, project_data_reactive, i18n, event_bus)
-isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = NULL) {
+isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = NULL, parent_session = NULL) {
   # Legacy alias for backwards compatibility within module
   global_data <- project_data_reactive
   moduleServer(id, function(input, output, session) {
@@ -1498,6 +1498,93 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
     )
 
    
+
+    # ---- Excel import (Standard Entry round-trip) ----
+    # Helper: does the module currently hold any elements?
+    .isa_has_elements <- function() {
+      any(vapply(list(isa_data$gb_panel_ids, isa_data$es_panel_ids, isa_data$mpf_panel_ids,
+                      isa_data$p_panel_ids, isa_data$a_panel_ids, isa_data$d_panel_ids),
+                 function(x) length(x) > 0 && any(nzchar(x)), logical(1)))
+    }
+
+    # Core import: read file -> apply -> guard -> notify/navigate.
+    do_import <- function(path) {
+      saved <- tryCatch(
+        read_standard_entry_workbook(path),
+        se_import_not_recognized = function(e) {
+          showNotification(i18n$t("modules.isa.data_entry.common.import_not_recognized"),
+                           type = "error", duration = 8, session = session)
+          NULL
+        },
+        error = function(e) {
+          showNotification(format_user_error(e, i18n = i18n,
+                           context_key = "common.messages.context_reading_excel_file"),
+                           type = "error", session = session)
+          NULL
+        })
+      if (is.null(saved)) return(invisible(NULL))
+
+      res <- apply_saved_isa(saved)
+
+      n_elems <- sum(vapply(c("goods_benefits","ecosystem_services","marine_processes",
+                              "pressures","activities","drivers"),
+                            function(k) if (is.data.frame(isa_data[[k]])) nrow(isa_data[[k]]) else 0L,
+                            integer(1)))
+      n_edges <- sum(vapply(isa_data$adjacency_matrices,
+                            function(m) if (is.matrix(m)) sum(nzchar(m), na.rm = TRUE) else 0L,
+                            integer(1)))
+
+      if (n_elems == 0L) {
+        showNotification(i18n$t("modules.isa.data_entry.common.import_not_recognized"),
+                         type = "error", duration = 8, session = session)
+        return(invisible(NULL))
+      }
+
+      data_initialized(TRUE)
+
+      if (isTRUE(res$fell_back)) {
+        showNotification(i18n$t("modules.isa.data_entry.common.import_links_defaulted"),
+                         type = "warning", duration = 10, session = session)
+      }
+
+      if (n_edges == 0L) {
+        showNotification(i18n$t("modules.isa.data_entry.common.import_no_connections"),
+                         type = "warning", duration = 10, session = session)
+        return(invisible(NULL))  # do not auto-navigate to an edgeless diagram
+      }
+
+      showNotification(i18n$t("modules.isa.data_entry.common.import_success"),
+                       type = "message", duration = 6, session = session)
+      if (!is.null(parent_session)) {
+        updateTabItems(parent_session, "sidebar_menu", "cld_viz")
+      }
+      invisible(NULL)
+    }
+
+    observeEvent(input$import_data, {
+      req(input$import_file)
+      path <- input$import_file$datapath
+      if (.isa_has_elements()) {
+        showModal(modalDialog(
+          title = i18n$t("modules.isa.data_entry.common.import_replace_title"),
+          i18n$t("modules.isa.data_entry.common.import_replace_warning"),
+          footer = tagList(
+            modalButton(i18n$t("common.buttons.cancel")),
+            actionButton(ns("import_confirm"), i18n$t("modules.isa.data_entry.common.import_data"),
+                         class = "btn-warning")
+          ),
+          easyClose = TRUE
+        ))
+      } else {
+        do_import(path)
+      }
+    }, ignoreInit = TRUE)
+
+    observeEvent(input$import_confirm, {
+      removeModal()
+      req(input$import_file)
+      do_import(input$import_file$datapath)
+    })
 
     # Download PDF guidance document
     output$download_guidance_pdf <- downloadHandler(

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -286,6 +286,7 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
       any_repaired <- FALSE
       any_rows_in <- FALSE
       any_panel_ids_out <- FALSE
+      # NB: reconcile the RAW saved df (uppercase ID), NOT the lowercased copy load_isa_elements_from_saved writes for the table view — keying on lowercase 'id' was the L6 'no elements' bug.
       for (key in names(id_load_map)) {
         saved_df <- saved_isa[[key]]
         if (is.data.frame(saved_df) && nrow(saved_df) > 0) {

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -267,58 +267,57 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
       })
     }
 
+    # Apply a saved/imported isa_data list into this module's reactiveValues.
+    # = load_isa_elements_from_saved (copies element dfs, adjacency_matrices,
+    #   loop_connections, case_info) + the L6-hardened id reconcile loop that
+    #   canonicalizes IDs and sets *_panel_ids. Shared by the project-load
+    #   observer and the Excel import handler. Caller sets data_initialized().
+    apply_saved_isa <- function(saved_isa) {
+      load_isa_elements_from_saved(isa_data, saved_isa)
+
+      id_load_map <- list(
+        goods_benefits     = list(prefix = ELEMENT_ID_PREFIX$welfare,    panel = "gb_panel_ids"),
+        ecosystem_services = list(prefix = ELEMENT_ID_PREFIX$impacts,    panel = "es_panel_ids"),
+        marine_processes   = list(prefix = ELEMENT_ID_PREFIX$states,     panel = "mpf_panel_ids"),
+        pressures          = list(prefix = ELEMENT_ID_PREFIX$pressures,  panel = "p_panel_ids"),
+        activities         = list(prefix = ELEMENT_ID_PREFIX$activities, panel = "a_panel_ids"),
+        drivers            = list(prefix = ELEMENT_ID_PREFIX$drivers,    panel = "d_panel_ids")
+      )
+      any_repaired <- FALSE
+      any_rows_in <- FALSE
+      any_panel_ids_out <- FALSE
+      for (key in names(id_load_map)) {
+        saved_df <- saved_isa[[key]]
+        if (is.data.frame(saved_df) && nrow(saved_df) > 0) {
+          any_rows_in <- TRUE
+          rec <- reconcile_loaded_element_ids(saved_df, id_load_map[[key]]$prefix, id_store)
+          isa_data[[key]] <- rec$df
+          panel_ids <- as.character(rec$df$ID)
+          isa_data[[id_load_map[[key]]$panel]] <- panel_ids
+          if (length(panel_ids) > 0 && any(nzchar(panel_ids))) any_panel_ids_out <- TRUE
+          if (isTRUE(rec$repaired)) any_repaired <- TRUE
+        } else {
+          isa_data[[id_load_map[[key]]$panel]] <- character(0)
+        }
+      }
+      if (any_repaired) {
+        showNotification(i18n$t("modules.isa.data_entry.common.ids_repaired_on_load"),
+                         type = "warning", duration = 8, session = session)
+      }
+      if (any_rows_in && !any_panel_ids_out) {
+        showNotification(i18n$t("modules.isa.data_entry.common.no_elements_loaded"),
+                         type = "warning", duration = 10, session = session)
+      }
+      invisible(NULL)
+    }
+
     # Load saved ISA data when a (different) project becomes active. Keyed on
-    # project_id so module saves — which don't change project_id — don't
-    # re-trigger a load and clobber in-progress edits (this exact loop was the
-    # ghost-row + duplicate-ID source before v1.13.0).
+    # project_id so module saves don't re-trigger a load and clobber edits.
     observeEvent(project_data_reactive()$project_id, {
       project <- project_data_reactive()
       if (!is.null(project) && !is.null(project$data) && !is.null(project$data$isa_data)) {
         debug_log("Loading saved ISA data on project change", "ISA Module")
-        load_isa_elements_from_saved(isa_data, project$data$isa_data)
-
-        # Repair legacy duplicate/blank IDs (a symptom of the old positional-ID
-        # bug) and ADOPT the resulting ids as the stable panel set, seeding the
-        # per-session counter past them so later add_* never collide. Reads the
-        # RAW saved df (uppercase ID) — load_isa_elements_from_saved lowercases
-        # for its table view, but the rest of the module keys on uppercase ID.
-        saved_isa <- project$data$isa_data
-        id_load_map <- list(
-          goods_benefits     = list(prefix = ELEMENT_ID_PREFIX$welfare,    panel = "gb_panel_ids"),
-          ecosystem_services = list(prefix = ELEMENT_ID_PREFIX$impacts,    panel = "es_panel_ids"),
-          marine_processes   = list(prefix = ELEMENT_ID_PREFIX$states,     panel = "mpf_panel_ids"),
-          pressures          = list(prefix = ELEMENT_ID_PREFIX$pressures,  panel = "p_panel_ids"),
-          activities         = list(prefix = ELEMENT_ID_PREFIX$activities, panel = "a_panel_ids"),
-          drivers            = list(prefix = ELEMENT_ID_PREFIX$drivers,    panel = "d_panel_ids")
-        )
-        any_repaired <- FALSE
-        any_rows_in <- FALSE
-        any_panel_ids_out <- FALSE
-        for (key in names(id_load_map)) {
-          saved_df <- saved_isa[[key]]
-          if (is.data.frame(saved_df) && nrow(saved_df) > 0) {
-            any_rows_in <- TRUE
-            rec <- reconcile_loaded_element_ids(saved_df, id_load_map[[key]]$prefix, id_store)
-            isa_data[[key]] <- rec$df
-            panel_ids <- as.character(rec$df$ID)
-            isa_data[[id_load_map[[key]]$panel]] <- panel_ids
-            if (length(panel_ids) > 0 && any(nzchar(panel_ids))) any_panel_ids_out <- TRUE
-            if (isTRUE(rec$repaired)) any_repaired <- TRUE
-          } else {
-            isa_data[[id_load_map[[key]]$panel]] <- character(0)
-          }
-        }
-        if (any_repaired) {
-          showNotification(i18n$t("modules.isa.data_entry.common.ids_repaired_on_load"),
-                           type = "warning", duration = 8, session = session)
-        }
-        # Surface the previously-silent failure: rows came in but nothing
-        # resolved to a panel id (e.g. an unrecognized legacy structure).
-        if (any_rows_in && !any_panel_ids_out) {
-          showNotification(i18n$t("modules.isa.data_entry.common.no_elements_loaded"),
-                           type = "warning", duration = 10, session = session)
-        }
-
+        apply_saved_isa(project$data$isa_data)
         data_initialized(TRUE)
       } else {
         debug_log("No saved ISA data found - starting fresh", "ISA Module")

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -1507,6 +1507,25 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
                  function(x) length(x) > 0 && any(nzchar(x)), logical(1)))
     }
 
+    # Clear all editable ISA state so an IMPORT is a true replace — prevents a
+    # fallback-style import (no Matrix_* sheets) from inheriting the previously
+    # loaded project's matrices/elements (stale edges / orphan IDs).
+    .reset_isa_state <- function() {
+      for (k in c("goods_benefits","ecosystem_services","marine_processes",
+                  "pressures","activities","drivers")) {
+        if (is.data.frame(isa_data[[k]])) isa_data[[k]] <- isa_data[[k]][0, , drop = FALSE]
+      }
+      for (p in c("gb_panel_ids","es_panel_ids","mpf_panel_ids",
+                  "p_panel_ids","a_panel_ids","d_panel_ids")) {
+        isa_data[[p]] <- character(0)
+      }
+      isa_data$adjacency_matrices   <- list()
+      isa_data$user_edited_matrices <- list()
+      if (is.data.frame(isa_data$loop_connections)) {
+        isa_data$loop_connections <- isa_data$loop_connections[0, , drop = FALSE]
+      }
+    }
+
     # Core import: read file -> apply -> guard -> notify/navigate.
     do_import <- function(path) {
       saved <- tryCatch(
@@ -1524,6 +1543,7 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
         })
       if (is.null(saved)) return(invisible(NULL))
 
+      .reset_isa_state()
       res <- apply_saved_isa(saved)
 
       n_elems <- sum(vapply(c("goods_benefits","ecosystem_services","marine_processes",

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-i18n-enforcement.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-i18n-enforcement.R
@@ -663,6 +663,37 @@ test_that("import_data_module has no hardcoded English column descriptions", {
   }
 })
 
+# ==============================================================================
+# TEST: Standard Entry import messages exist in all 9 languages
+# ==============================================================================
+
+test_that("Standard Entry import keys exist in all 9 languages", {
+  test_dir <- getwd()
+  root <- if (basename(test_dir) == "testthat") dirname(dirname(test_dir)) else test_dir
+  fp <- file.path(root, "translations", "modules", "isa_data_entry.json")
+  skip_if_not(file.exists(fp), "isa_data_entry.json not found")
+  langs <- c("en", "es", "fr", "de", "lt", "pt", "it", "no", "el")
+  keys <- c(
+    "import_success",
+    "import_not_recognized",
+    "import_links_defaulted",
+    "import_no_connections",
+    "import_replace_title",
+    "import_replace_warning"
+  )
+  tr <- jsonlite::fromJSON(fp, simplifyVector = FALSE)
+  for (k in keys) {
+    full <- paste0("modules.isa.data_entry.common.", k)
+    for (lang in langs) {
+      val <- tryCatch(tr[["translation"]][[full]][[lang]], error = function(e) NULL)
+      expect_true(
+        !is.null(val) && nzchar(val),
+        info = paste("missing or empty:", full, "for", lang)
+      )
+    }
+  }
+})
+
 test_that("import_data.json has the 7 new column-description keys", {
   test_dir <- getwd()
   root <- if (basename(test_dir) == "testthat") dirname(dirname(test_dir)) else test_dir

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
@@ -95,3 +95,66 @@ test_that("import handler loads a Matrix_* workbook, populates panels + matrices
       expect_equal(rv$adjacency_matrices$es_gb["ES001", "GB001"], "+Strong:High")
   })
 })
+
+test_that("import guard: elements but no connections — panels load, no crash (L5 defense)", {
+  source_for_test("functions/isa_export_helpers.R")
+  source_for_test("functions/standard_entry_excel_import.R")
+
+  # Two elements in unconnected categories; no Matrix_* sheets, empty/absent links.
+  isa <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = character(), Name = character()),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = "D001", Name = "Demand", Type = "", Description = "",
+                         LinkedA = "", Trend = "", Controllability = "", stringsAsFactors = FALSE)
+    # no adjacency_matrices -> reader writes no Matrix_* sheets; fallback finds no
+    # valid (src,tgt) pair (activities empty), so zero edges.
+  )
+  wb <- openxlsx::createWorkbook(); write_isa_element_sheets(wb, isa, include_adjacency = TRUE)
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  testServer(isa_data_entry_server,
+    args = list(project_data_reactive = reactiveVal(init_session_data()),
+                i18n = fake_i18n, parent_session = NULL), {
+      session$setInputs(import_file = data.frame(
+        name = "x.xlsx", size = 1, type = "", datapath = tmp, stringsAsFactors = FALSE))
+      session$setInputs(import_data = 1)
+      session$flushReact()
+      rv <- session$getReturned()()
+      # elements loaded (import ran through apply_saved_isa)
+      expect_setequal(rv$gb_panel_ids, "GB001")
+      expect_setequal(rv$d_panel_ids, "D001")
+      # but no edges were produced
+      n_edges <- sum(vapply(rv$adjacency_matrices,
+                            function(m) if (is.matrix(m)) sum(nzchar(m) & !is.na(m)) else 0L,
+                            integer(1)))
+      expect_equal(n_edges, 0)
+  })
+})
+
+test_that("import of an unrecognized workbook is a clean no-op (state unchanged)", {
+  source_for_test("functions/standard_entry_excel_import.R")
+
+  # A workbook with no Standard-Entry element sheets and no Matrix_* sheets.
+  wb <- openxlsx::createWorkbook()
+  openxlsx::addWorksheet(wb, "RandomSheet")
+  openxlsx::writeData(wb, "RandomSheet", data.frame(foo = 1, bar = 2))
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  testServer(isa_data_entry_server,
+    args = list(project_data_reactive = reactiveVal(init_session_data()),
+                i18n = fake_i18n, parent_session = NULL), {
+      session$setInputs(import_file = data.frame(
+        name = "bad.xlsx", size = 1, type = "", datapath = tmp, stringsAsFactors = FALSE))
+      session$setInputs(import_data = 1)
+      session$flushReact()
+      rv <- session$getReturned()()
+      # nothing imported — all panels remain empty
+      expect_length(rv$gb_panel_ids, 0)
+      expect_length(rv$d_panel_ids, 0)
+      expect_length(rv$es_panel_ids, 0)
+  })
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
@@ -1,0 +1,43 @@
+# tests/testthat/test-isa-import-handler.R
+source_for_test(c("modules/isa_data_entry_module.R",
+                  "functions/isa_form_builders.R",
+                  "functions/data_structure.R"))
+
+# source_for_test() writes to .GlobalEnv, but helper-stubs.R defines a stub
+# isa_data_entry_server in testthat's helper environment, which SHADOWS
+# .GlobalEnv during name lookup. Re-bind the real implementation into this
+# file's env so testServer() drives the real module, not the stub.
+isa_data_entry_server <- get("isa_data_entry_server", envir = .GlobalEnv)
+
+fake_i18n <- list(t = function(x, ...) x)
+
+# A saved project shaped like project$data$isa_data, with elements + one matrix.
+make_saved_project <- function() {
+  isa <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "",
+                                stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001", Mechanism = "", Confidence = "High",
+                                    stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character()),
+    adjacency_matrices = list(
+      es_gb = matrix("+High:High", 1, 1, dimnames = list("ES001", "GB001"))
+    )
+  )
+  list(project_id = "p1", name = "P1", data = list(isa_data = isa))
+}
+
+test_that("project-load observer populates panel_ids and loads matrices (characterization)", {
+  testServer(isa_data_entry_server,
+    args = list(project_data_reactive = reactiveVal(make_saved_project()), i18n = fake_i18n), {
+      session$flushReact()
+      rv <- session$getReturned()()
+      expect_setequal(rv$gb_panel_ids, "GB001")
+      expect_setequal(rv$es_panel_ids, "ES001")
+      expect_equal(rv$adjacency_matrices$es_gb["ES001", "GB001"], "+High:High")
+  })
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
@@ -135,6 +135,62 @@ test_that("import guard: elements but no connections — panels load, no crash (
   })
 })
 
+test_that("import replaces prior project state (no stale matrices/elements)", {
+  source_for_test("functions/isa_export_helpers.R")
+  source_for_test("functions/standard_entry_excel_import.R")
+
+  # Project A loaded first: faithful es_gb "+High:High" AND a driver D001.
+  projA <- list(project_id = "A", name = "A", data = list(isa_data = list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001", Mechanism = "", Confidence = "High", stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = "D001", Name = "Demand", Type = "", Description = "",
+                         LinkedA = "", Trend = "", Controllability = "", stringsAsFactors = FALSE),
+    adjacency_matrices = list(es_gb = matrix("+High:High", 1, 1, dimnames = list("ES001", "GB001")))
+  )))
+
+  # Import B: element sheets only (NO Matrix_*); ES Confidence "Low"; NO drivers.
+  isaB <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001", Mechanism = "", Confidence = "Low", stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character())
+  )
+  wb <- openxlsx::createWorkbook(); write_isa_element_sheets(wb, isaB, include_adjacency = FALSE)
+  tmpB <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmpB, overwrite = TRUE)
+
+  testServer(isa_data_entry_server,
+    args = list(project_data_reactive = reactiveVal(projA), i18n = fake_i18n, parent_session = NULL), {
+      session$flushReact()  # load project A
+      rvA <- session$getReturned()()
+      expect_equal(rvA$adjacency_matrices$es_gb["ES001", "GB001"], "+High:High")
+      expect_setequal(rvA$d_panel_ids, "D001")
+
+      # Import B; state is non-empty so the confirm modal path is exercised.
+      session$setInputs(import_file = data.frame(
+        name = "b.xlsx", size = 1, type = "", datapath = tmpB, stringsAsFactors = FALSE))
+      session$setInputs(import_data = 1)     # shows confirm modal
+      session$flushReact()
+      session$setInputs(import_confirm = 1)  # confirm replace
+      session$flushReact()
+
+      rv <- session$getReturned()()
+      # B's fallback es_gb ("+Medium:Low") REPLACED A's faithful "+High:High"
+      expect_equal(rv$adjacency_matrices$es_gb["ES001", "GB001"], "+Medium:Low")
+      # A's driver is fully gone (element df cleared, not just the panel tracker)
+      expect_equal(nrow(rv$drivers), 0)
+      expect_length(rv$d_panel_ids, 0)
+  })
+})
+
 test_that("import of an unrecognized workbook is a clean no-op (state unchanged)", {
   source_for_test("functions/standard_entry_excel_import.R")
 

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
@@ -63,3 +63,35 @@ test_that("apply_saved_isa rebuilds forward matrices from Linked* when none supp
       expect_equal(rv$adjacency_matrices$es_gb["ES001", "GB001"], "+Medium:High")
   })
 })
+
+test_that("import handler loads a Matrix_* workbook, populates panels + matrices", {
+  source_for_test("functions/isa_export_helpers.R")
+  source_for_test("functions/standard_entry_excel_import.R")
+
+  isa <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001", Mechanism = "", Confidence = "High", stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character()),
+    adjacency_matrices = list(es_gb = matrix("+Strong:High", 1, 1, dimnames = list("ES001", "GB001")))
+  )
+  wb <- openxlsx::createWorkbook(); write_isa_element_sheets(wb, isa, include_adjacency = TRUE)
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  testServer(isa_data_entry_server,
+    args = list(project_data_reactive = reactiveVal(init_session_data()),
+                i18n = fake_i18n, parent_session = NULL), {
+      session$setInputs(import_file = data.frame(
+        name = "x.xlsx", size = 1, type = "", datapath = tmp, stringsAsFactors = FALSE))
+      session$setInputs(import_data = 1)   # click Import
+      session$flushReact()
+      rv <- session$getReturned()()
+      expect_setequal(rv$es_panel_ids, "ES001")
+      expect_setequal(rv$gb_panel_ids, "GB001")
+      expect_equal(rv$adjacency_matrices$es_gb["ES001", "GB001"], "+Strong:High")
+  })
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
@@ -41,3 +41,25 @@ test_that("project-load observer populates panel_ids and loads matrices (charact
       expect_equal(rv$adjacency_matrices$es_gb["ES001", "GB001"], "+High:High")
   })
 })
+
+test_that("apply_saved_isa rebuilds forward matrices from Linked* when none supplied", {
+  saved <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001", Mechanism = "", Confidence = "High", stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character())
+    # NOTE: no adjacency_matrices
+  )
+  proj <- list(project_id = "pX", name = "PX", data = list(isa_data = saved))
+
+  testServer(isa_data_entry_server,
+    args = list(project_data_reactive = reactiveVal(proj), i18n = fake_i18n), {
+      session$flushReact()
+      rv <- session$getReturned()()
+      expect_equal(rv$adjacency_matrices$es_gb["ES001", "GB001"], "+Medium:High")
+  })
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
@@ -79,3 +79,24 @@ test_that("faithful round-trip preserves dimnames + cells for a non-square matri
   expect_equal(m["ES001","GB003"], "+Medium:Medium")
   expect_equal(m["ES002","GB001"], "")   # empty cell round-trips to ""
 })
+
+test_that("rejects a non-Standard-Entry workbook (generic Elements/Connections)", {
+  wb <- openxlsx::createWorkbook()
+  openxlsx::addWorksheet(wb, "Elements");    openxlsx::writeData(wb, "Elements", data.frame(Label = "x", type = "Driver"))
+  openxlsx::addWorksheet(wb, "Connections"); openxlsx::writeData(wb, "Connections", data.frame(From = "x", To = "y"))
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  expect_error(read_standard_entry_workbook(tmp), class = "se_import_not_recognized")
+})
+
+test_that("rejects an element sheet that lacks ID/Name columns", {
+  wb <- openxlsx::createWorkbook()
+  openxlsx::addWorksheet(wb, "Drivers"); openxlsx::writeData(wb, "Drivers", data.frame(Foo = 1, Bar = 2))
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  expect_error(read_standard_entry_workbook(tmp), class = "se_import_not_recognized")
+})
+
+test_that("missing file raises a clear error", {
+  expect_error(read_standard_entry_workbook(tempfile(fileext = ".xlsx")), "file not found")
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
@@ -1,0 +1,45 @@
+# tests/testthat/test-standard-entry-excel-import.R
+source_for_test("functions/standard_entry_excel_import.R")
+library(openxlsx)
+
+# Build an isa_data-like list, export it the way the VISIBLE button does
+# (write_isa_element_sheets include_adjacency=TRUE), then read it back.
+source_for_test("functions/isa_export_helpers.R")
+
+make_isa <- function() {
+  list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001", Mechanism = "", Confidence = "High", stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = "MPF001", Name = "Prod", Type = "", Description = "",
+                                  LinkedES = "ES001", Mechanism = "", Spatial = "", stringsAsFactors = FALSE),
+    pressures = data.frame(ID = "P001", Name = "Fishing", Type = "", Description = "",
+                           LinkedMPF = "MPF001", Intensity = "", Spatial = "", Temporal = "", stringsAsFactors = FALSE),
+    activities = data.frame(ID = "A001", Name = "Trawl", Sector = "", Description = "",
+                            LinkedP = "P001", Scale = "", Frequency = "", stringsAsFactors = FALSE),
+    drivers = data.frame(ID = "D001", Name = "Demand", Type = "", Description = "",
+                         LinkedA = "A001", Trend = "", Controllability = "", stringsAsFactors = FALSE),
+    adjacency_matrices = list(
+      es_gb = matrix("+Strong:High", 1, 1, dimnames = list("ES001", "GB001")),
+      gb_d  = matrix("-Weak:Medium", 1, 1, dimnames = list("GB001", "D001"))
+    )
+  )
+}
+
+test_that("faithful round-trip: Matrix_* sheets reconstruct exact edge cells", {
+  isa <- make_isa()
+  wb <- openxlsx::createWorkbook()
+  write_isa_element_sheets(wb, isa, include_adjacency = TRUE)
+  tmp <- tempfile(fileext = ".xlsx")
+  openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  out <- read_standard_entry_workbook(tmp)
+
+  expect_equal(as.character(out$goods_benefits$ID), "GB001")
+  expect_equal(as.character(out$drivers$ID), "D001")
+  expect_equal(out$adjacency_matrices$es_gb["ES001", "GB001"], "+Strong:High")
+  expect_equal(out$adjacency_matrices$gb_d["GB001", "D001"], "-Weak:Medium")
+  # all element columns coerced to character
+  expect_true(all(vapply(out$ecosystem_services, is.character, logical(1))))
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
@@ -43,3 +43,39 @@ test_that("faithful round-trip: Matrix_* sheets reconstruct exact edge cells", {
   # all element columns coerced to character
   expect_true(all(vapply(out$ecosystem_services, is.character, logical(1))))
 })
+
+test_that("faithful round-trip preserves dimnames + cells for a non-square matrix", {
+  isa <- list(
+    goods_benefits = data.frame(ID = c("GB001","GB002","GB003"), Name = c("A","B","C"),
+                                Type = "", Description = "", Stakeholder = "", Importance = "", Trend = "",
+                                stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = c("ES001","ES002"), Name = c("X","Y"),
+                                    Type = "", Description = "", LinkedGB = c("GB001","GB002"),
+                                    Mechanism = "", Confidence = "Medium", stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character()),
+    adjacency_matrices = list(
+      es_gb = matrix(c("+Strong:High", "",            # ES001->GB001, ES002->GB001
+                       "", "-Weak:Low",               # ES001->GB002, ES002->GB002
+                       "+Medium:Medium", ""),         # ES001->GB003, ES002->GB003
+                     nrow = 2, ncol = 3,
+                     dimnames = list(c("ES001","ES002"), c("GB001","GB002","GB003")))
+    )
+  )
+  wb <- openxlsx::createWorkbook()
+  write_isa_element_sheets(wb, isa, include_adjacency = TRUE)
+  tmp <- tempfile(fileext = ".xlsx")
+  openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  out <- read_standard_entry_workbook(tmp)
+  m <- out$adjacency_matrices$es_gb
+
+  expect_equal(rownames(m), c("ES001","ES002"))
+  expect_equal(colnames(m), c("GB001","GB002","GB003"))
+  expect_equal(m["ES001","GB001"], "+Strong:High")
+  expect_equal(m["ES002","GB002"], "-Weak:Low")
+  expect_equal(m["ES001","GB003"], "+Medium:Medium")
+  expect_equal(m["ES002","GB001"], "")   # empty cell round-trips to ""
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-standard-entry-excel-import.R
@@ -100,3 +100,15 @@ test_that("rejects an element sheet that lacks ID/Name columns", {
 test_that("missing file raises a clear error", {
   expect_error(read_standard_entry_workbook(tempfile(fileext = ".xlsx")), "file not found")
 })
+
+test_that("no Matrix_* sheets: reader returns elements with Linked* and no adjacency_matrices", {
+  isa <- make_isa()
+  wb <- openxlsx::createWorkbook()
+  # Element sheets ONLY (mimic create_isa_analysis_workbook: no adjacency)
+  write_isa_element_sheets(wb, isa, include_adjacency = FALSE)
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  out <- read_standard_entry_workbook(tmp)
+  expect_null(out$adjacency_matrices)
+  expect_equal(as.character(out$ecosystem_services$LinkedGB), "GB001")
+})

--- a/MarineSABRES_SES_Shiny/translations/modules/isa_data_entry.json
+++ b/MarineSABRES_SES_Shiny/translations/modules/isa_data_entry.json
@@ -1540,6 +1540,72 @@
       "no": "Importer data",
       "el": "Εισαγωγή Δεδομένα"
     },
+    "modules.isa.data_entry.common.import_links_defaulted": {
+      "en": "Connections were rebuilt with default values (positive, medium strength) because this file did not store link strengths. Re-export to preserve them.",
+      "es": "Las conexiones se reconstruyeron con valores predeterminados (positivo, fuerza media) porque este archivo no almacenaba las intensidades de los vínculos. Vuelva a exportar para conservarlos.",
+      "fr": "Les connexions ont été reconstruites avec des valeurs par défaut (positif, intensité moyenne) car ce fichier ne contenait pas les intensités des liens. Ré-exportez pour les conserver.",
+      "de": "Verbindungen wurden mit Standardwerten (positiv, mittlere Stärke) neu erstellt, da diese Datei keine Verbindungsstärken enthielt. Erneut exportieren, um sie zu erhalten.",
+      "lt": "Ryšiai buvo atstatyti su numatytomis reikšmėmis (teigiami, vidutinis stiprumas), nes šiame faile nebuvo saugomi ryšių stiprumai. Eksportuokite iš naujo, kad juos išsaugotumėte.",
+      "pt": "As conexões foram reconstruídas com valores predefinidos (positivo, força média) porque este ficheiro não armazenava as intensidades dos vínculos. Exporte novamente para as preservar.",
+      "it": "Le connessioni sono state ricostruite con valori predefiniti (positivo, intensità media) perché questo file non memorizzava le intensità dei collegamenti. Riesportare per conservarle.",
+      "no": "Forbindelsene ble gjenoppbygd med standardverdier (positiv, middels styrke) fordi denne filen ikke lagret koblingsstyrker. Eksporter på nytt for å bevare dem.",
+      "el": "Οι συνδέσεις αναδημιουργήθηκαν με προεπιλεγμένες τιμές (θετικές, μέτρια ισχύς) επειδή αυτό το αρχείο δεν αποθήκευε τις εντάσεις των συνδέσεων. Εξαγάγετε ξανά για να τις διατηρήσετε."
+    },
+    "modules.isa.data_entry.common.import_no_connections": {
+      "en": "Imported elements, but no connections were found — the diagram will have no links.",
+      "es": "Se importaron elementos, pero no se encontraron conexiones — el diagrama no tendrá vínculos.",
+      "fr": "Éléments importés, mais aucune connexion n'a été trouvée — le diagramme n'aura pas de liens.",
+      "de": "Elemente importiert, aber keine Verbindungen gefunden — das Diagramm wird keine Verknüpfungen haben.",
+      "lt": "Elementai importuoti, tačiau ryšių nerasta — diagramoje nebus jungčių.",
+      "pt": "Elementos importados, mas não foram encontradas conexões — o diagrama não terá vínculos.",
+      "it": "Elementi importati, ma non sono state trovate connessioni — il diagramma non avrà collegamenti.",
+      "no": "Elementer ble importert, men ingen forbindelser ble funnet — diagrammet vil ikke ha lenker.",
+      "el": "Τα στοιχεία εισήχθησαν, αλλά δεν βρέθηκαν συνδέσεις — το διάγραμμα δεν θα έχει συνδέσμους."
+    },
+    "modules.isa.data_entry.common.import_not_recognized": {
+      "en": "This file isn't a Standard Entry Excel export. Please choose a workbook created with the 'Export to Excel' button.",
+      "es": "Este archivo no es una exportación de Excel de Entrada Estándar. Elija un libro de trabajo creado con el botón 'Exportar a Excel'.",
+      "fr": "Ce fichier n'est pas une exportation Excel d'Entrée Standard. Veuillez choisir un classeur créé avec le bouton 'Exporter vers Excel'.",
+      "de": "Diese Datei ist kein Standard-Eintrag-Excel-Export. Bitte wählen Sie eine Arbeitsmappe aus, die mit der Schaltfläche 'Nach Excel exportieren' erstellt wurde.",
+      "lt": "Šis failas nėra standartinio įrašo Excel eksportas. Pasirinkite darbaknygę, sukurtą mygtuku 'Eksportuoti į Excel'.",
+      "pt": "Este ficheiro não é uma exportação Excel de Entrada Padrão. Escolha um livro de trabalho criado com o botão 'Exportar para Excel'.",
+      "it": "Questo file non è un'esportazione Excel di Inserimento Standard. Scegliere una cartella di lavoro creata con il pulsante 'Esporta in Excel'.",
+      "no": "Denne filen er ikke en Standard Oppføring Excel-eksport. Velg en arbeidsbok opprettet med knappen 'Eksporter til Excel'.",
+      "el": "Αυτό το αρχείο δεν είναι εξαγωγή Excel Τυπικής Καταχώρησης. Επιλέξτε ένα βιβλίο εργασίας που δημιουργήθηκε με το κουμπί 'Εξαγωγή to Excel'."
+    },
+    "modules.isa.data_entry.common.import_replace_title": {
+      "en": "Replace current entries?",
+      "es": "¿Reemplazar entradas actuales?",
+      "fr": "Remplacer les entrées actuelles ?",
+      "de": "Aktuelle Einträge ersetzen?",
+      "lt": "Pakeisti dabartinius įrašus?",
+      "pt": "Substituir entradas atuais?",
+      "it": "Sostituire le voci correnti?",
+      "no": "Erstatte gjeldende oppføringer?",
+      "el": "Αντικατάσταση τρεχουσών καταχωρήσεων;"
+    },
+    "modules.isa.data_entry.common.import_replace_warning": {
+      "en": "Importing will replace your current Standard Entry data. Continue?",
+      "es": "La importación reemplazará sus datos actuales de Entrada Estándar. ¿Continuar?",
+      "fr": "L'importation remplacera vos données d'Entrée Standard actuelles. Continuer ?",
+      "de": "Der Import ersetzt Ihre aktuellen Standard-Eintrag-Daten. Fortfahren?",
+      "lt": "Importavimas pakeis dabartinius standartinio įrašo duomenis. Tęsti?",
+      "pt": "A importação substituirá os seus dados atuais de Entrada Padrão. Continuar?",
+      "it": "L'importazione sostituirà i dati correnti di Inserimento Standard. Continuare?",
+      "no": "Import vil erstatte dine gjeldende Standard Oppføring-data. Fortsette?",
+      "el": "Η εισαγωγή θα αντικαταστήσει τα τρέχοντα δεδομένα Τυπικής Καταχώρησης. Συνέχεια;"
+    },
+    "modules.isa.data_entry.common.import_success": {
+      "en": "ISA data imported. Open the CLD Visualization tab to see the diagram, then the analysis tabs for results.",
+      "es": "Datos ISA importados. Abra la pestaña Visualización CLD para ver el diagrama y luego las pestañas de análisis para los resultados.",
+      "fr": "Données ISA importées. Ouvrez l'onglet Visualisation CLD pour voir le diagramme, puis les onglets d'analyse pour les résultats.",
+      "de": "ISA-Daten importiert. Öffnen Sie die Registerkarte CLD-Visualisierung, um das Diagramm anzuzeigen, dann die Analyseregisterkarten für die Ergebnisse.",
+      "lt": "ISA duomenys importuoti. Atidarykite CLD vizualizacija skirtuką, kad pamatytumėte diagramą, o tada analizės skirtukus rezultatams.",
+      "pt": "Dados ISA importados. Abra o separador Visualização CLD para ver o diagrama e, em seguida, os separadores de análise para os resultados.",
+      "it": "Dati ISA importati. Aprire la scheda Visualizzazione CLD per vedere il diagramma, poi le schede di analisi per i risultati.",
+      "no": "ISA-data importert. Åpne fanen CLD-visualisering for å se diagrammet, deretter analysefanene for resultater.",
+      "el": "Τα δεδομένα ISA εισήχθησαν. Ανοίξτε την καρτέλα Οπτικοποίηση CLD για να δείτε το διάγραμμα και στη συνέχεια τις καρτέλες ανάλυσης για αποτελέσματα."
+    },
     "modules.isa.data_entry.common.importexport_and_data_management": {
       "en": "Import/Export and Data Management",
       "es": "Importación/Exportación y Gestión de Datos",


### PR DESCRIPTION
## What & why (fixes laguna feedback **L5**)

> *"They don't let me load my excel sheet, which was generated from Standard entry. Where should I load it then? And how could I get the results? The diagram?"*

The Standard Entry **Import** button was dead (no handler) and no importer could read the Standard Entry Excel export. This wires the button to a true round-trip:

- **Read the `Matrix_*` sheets the export already writes.** The visible "Export to Excel" button uses `write_isa_element_sheets(..., include_adjacency = TRUE)`, which writes per-category element sheets **plus** `Matrix_*` adjacency sheets with real polarity/strength. The new reader `read_standard_entry_workbook()` reverses that exactly → faithful diagram restored (closing-loop `gb_d` included). **No export change needed.**
- **`Linked*` fallback** for matrix-less exports (e.g. `create_isa_analysis_workbook`): rebuilds the five forward transitions from per-category `Linked*` columns at default `+`/`Medium`, with an explicit "links defaulted" notice.
- **Reuses the project-load path:** the load logic is factored into `apply_saved_isa()`, shared by the project-load observer and import — so import inherits the L6-hardened ID reconciliation.
- **Replace semantics + confirm:** import replaces current Standard Entry state (with a confirm dialog when state is non-empty); `do_import` resets prior state first so a fallback import can't inherit a previous project's matrices.
- **No false success:** strict format detection rejects non-SE workbooks (`se_import_not_recognized`); a guard blocks "success + navigate" unless the model has elements **and** edges.
- **Auto-navigate to the CLD tab** after a verified import; success message also points to the analysis tabs.
- Adds `parent_session` param (passed in `app.R`) for the cross-module navigation.

## Design / process
Spec → 5-angle parallel review (which corrected the original premise: target `Matrix_*` sheets, not a `Connections` export) → plan → subagent-driven TDD with two-stage review per task → final whole-branch review (caught the stale-state replace bug, fixed here).

Spec: `docs/superpowers/specs/2026-06-01-standard-entry-excel-roundtrip-design.md`

## Tests
New `test-standard-entry-excel-import.R` (faithful round-trip incl. non-square matrix, `Linked*` fallback, strict-detection negatives, missing file) and additions to `test-isa-import-handler.R` (characterization of project-load, handler happy-path, **n_edges==0 guard**, unrecognized no-op, **import-over-existing replace via the confirm-modal path**). i18n keys ×9 enforced. **Full suite: 7393 passing, 0 failures.**

## Files
- **new** `functions/standard_entry_excel_import.R` — the reader
- `modules/isa_data_entry_module.R` — `apply_saved_isa` extraction + `Linked*` fallback + import handler + reset + `parent_session`
- `app.R` — pass `parent_session = session`
- `global.R` — source the new file
- `translations/modules/isa_data_entry.json` — 6 keys ×9 languages
- tests + i18n enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Standard Entry Excel import with validation and user confirmation when replacing existing data.
  * Automatic reconstruction of missing connection values during import.
  * Multilingual support for import messages and error handling (9 languages).

* **Tests**
  * Added comprehensive test coverage for import functionality and data validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->