### PR TITLE
fix: recover legacy Standard-Entry Excel imports (name-based LinkedX, per-transition fallback)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/matrix_from_linked.R
+++ b/MarineSABRES_SES_Shiny/functions/matrix_from_linked.R
@@ -179,3 +179,89 @@ rebuild_matrix_from_linked <- function(element_df, linked_col,
     dropped_user_edits = dropped
   )
 }
+
+# ---------------------------------------------------------------------------
+# Name-based recovery of legacy LinkedX values
+# ---------------------------------------------------------------------------
+# Legacy (v1.13.x) Standard Entry exports store forward connections in the
+# LinkedX columns in LABEL form ("MPF005: Biodiversity richness"), and may carry
+# DUPLICATE element IDs (the old positional-ID bug). After reconcile repairs the
+# duplicates, the stale numeric IDs in the labels no longer identify the right
+# element — but the NAME still does. These helpers resolve each link by NAME
+# first (robust to duplicate-ID repair), falling back to a bare-ID match.
+
+# Light normalization for name comparison (trim, collapse internal whitespace,
+# lowercase). Deliberately simple — element names are user text, not metachars.
+.linked_norm_name <- function(x) tolower(trimws(gsub("\\s+", " ", as.character(x))))
+
+#' Resolve a (possibly label-form, possibly pipe-delimited) LinkedX value to
+#' target element IDs, preferring NAME match over a stale ID.
+#'
+#' @param linked_value scalar LinkedX cell, e.g. "MPF005: Biodiversity richness"
+#'   or "GB001" or "GB001: Food|GB002: Energy". NULL/NA/"" -> character(0).
+#' @param target_df data frame of candidate targets with `ID` and (ideally)
+#'   `Name` columns (already reconciled to unique IDs).
+#' @return unique character vector of matched target IDs (order preserved).
+resolve_linked_to_target_ids <- function(linked_value, target_df) {
+  segs <- parse_linked(linked_value)
+  if (length(segs) == 0) return(character(0))
+  if (!is.data.frame(target_df) || nrow(target_df) == 0 || !("ID" %in% names(target_df)))
+    return(character(0))
+
+  tgt_ids   <- as.character(target_df$ID)
+  tgt_names <- if ("Name" %in% names(target_df)) .linked_norm_name(target_df$Name) else rep(NA_character_, length(tgt_ids))
+
+  out <- character(0)
+  for (seg in segs) {
+    has_colon <- grepl(":", seg, fixed = TRUE)
+    id_part   <- trimws(sub(":.*$", "", seg))
+    name_part <- if (has_colon) trimws(sub("^[^:]*:\\s*", "", seg)) else ""
+    resolved  <- NA_character_
+
+    # 1) NAME match (the legacy label carries it; robust to duplicate-ID repair)
+    if (nzchar(name_part)) {
+      hit <- which(tgt_names == .linked_norm_name(name_part))
+      if (length(hit) >= 1) resolved <- tgt_ids[hit[1]]
+    }
+    # 2) fall back to bare-ID match
+    if (is.na(resolved) && nzchar(id_part) && id_part %in% tgt_ids) resolved <- id_part
+
+    if (!is.na(resolved)) out <- c(out, resolved)
+  }
+  unique(out)
+}
+
+#' Rebuild a source x target adjacency matrix from a label-form LinkedX column,
+#' resolving each link by NAME-then-ID. Cells default to
+#' "<polarity><strength>:<confidence>" (confidence taken from the source row's
+#' Confidence column when present, else the default). Edges are written at the
+#' resolved (reconciled) target ID, so duplicate-ID corruption in the source
+#' file does not misplace them.
+#'
+#' @return a character matrix (rows = source_df$ID, cols = target_df$ID).
+rebuild_forward_matrix_by_name <- function(source_df, linked_col, target_df,
+                                           element_confidence_col = "Confidence",
+                                           default_polarity = "+",
+                                           default_strength = "Medium",
+                                           default_confidence = "Medium") {
+  src_ids <- as.character(source_df$ID)
+  tgt_ids <- as.character(target_df$ID)
+  out <- matrix("", nrow = length(src_ids), ncol = length(tgt_ids),
+                dimnames = list(src_ids, tgt_ids))
+  has_conf <- element_confidence_col %in% names(source_df)
+  if (!(linked_col %in% names(source_df))) return(out)
+
+  for (i in seq_len(nrow(source_df))) {
+    sid <- as.character(source_df$ID[i])
+    if (!(sid %in% src_ids)) next
+    confidence <- if (has_conf) {
+      v <- source_df[[element_confidence_col]][i]
+      if (is.null(v) || is.na(v) || !nzchar(as.character(v))) default_confidence else as.character(v)
+    } else default_confidence
+    cell <- paste0(default_polarity, default_strength, ":", confidence)
+    for (tid in resolve_linked_to_target_ids(source_df[[linked_col]][i], target_df)) {
+      out[sid, tid] <- cell
+    }
+  }
+  out
+}

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -301,31 +301,39 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
           isa_data[[id_load_map[[key]]$panel]] <- character(0)
         }
       }
-      # Fallback: if no adjacency_matrices were supplied (e.g. an export without
-      # Matrix_* sheets), rebuild the five forward transitions from the per-category
-      # Linked* columns at default +/Medium. gb_d (closing loop) is NOT recoverable
-      # this way. Caller shows a notice when fell_back is TRUE.
+      # Per-transition LinkedX fallback. For EACH forward transition, if its
+      # faithful Matrix_* matrix is absent or has NO non-empty cells, rebuild it
+      # from the per-category LinkedX column. Legacy v1.13.x exports stored
+      # forward links only in the LinkedX columns (label form "ID: Name") and
+      # exported EMPTY forward matrices, so an all-or-nothing gate would leave
+      # the diagram edgeless whenever any one matrix (e.g. gb_d) had data.
+      # Links resolve by NAME first (robust to the old duplicate-ID bug), so an
+      # edge attaches to the correct element after reconcile renames duplicates.
+      # Faithful matrices that DO carry edges (e.g. gb_d) are kept as-is.
       fell_back <- FALSE
-      if (is.null(isa_data$adjacency_matrices) || length(isa_data$adjacency_matrices) == 0) {
-        linked_map <- list(
-          es_gb  = list(src = "ecosystem_services", col = "LinkedGB",  tgt = "goods_benefits"),
-          mpf_es = list(src = "marine_processes",   col = "LinkedES",  tgt = "ecosystem_services"),
-          p_mpf  = list(src = "pressures",          col = "LinkedMPF", tgt = "marine_processes"),
-          a_p    = list(src = "activities",         col = "LinkedP",   tgt = "pressures"),
-          d_a    = list(src = "drivers",            col = "LinkedA",   tgt = "activities")
-        )
-        for (mk in names(linked_map)) {
-          m <- linked_map[[mk]]
-          src_df <- isa_data[[m$src]]
-          tgt_df <- isa_data[[m$tgt]]
-          if (is.data.frame(src_df) && nrow(src_df) > 0 && m$col %in% names(src_df) &&
-              is.data.frame(tgt_df) && nrow(tgt_df) > 0) {
-            rb <- rebuild_matrix_from_linked(
-              element_df = src_df, linked_col = m$col,
-              source_ids = as.character(src_df$ID), target_ids = as.character(tgt_df$ID),
-              element_confidence_col = "Confidence")
-            isa_data$adjacency_matrices[[mk]] <- rb$matrix
-            isa_data$user_edited_matrices[[mk]] <- rb$user_edited
+      linked_map <- list(
+        es_gb  = list(src = "ecosystem_services", col = "LinkedGB",  tgt = "goods_benefits"),
+        mpf_es = list(src = "marine_processes",   col = "LinkedES",  tgt = "ecosystem_services"),
+        p_mpf  = list(src = "pressures",          col = "LinkedMPF", tgt = "marine_processes"),
+        a_p    = list(src = "activities",         col = "LinkedP",   tgt = "pressures"),
+        d_a    = list(src = "drivers",            col = "LinkedA",   tgt = "activities")
+      )
+      for (mk in names(linked_map)) {
+        m <- linked_map[[mk]]
+        src_df   <- isa_data[[m$src]]
+        tgt_df   <- isa_data[[m$tgt]]
+        existing <- isa_data$adjacency_matrices[[mk]]
+        has_edges <- is.matrix(existing) && any(nzchar(existing) & !is.na(existing))
+        if (!has_edges &&
+            is.data.frame(src_df) && nrow(src_df) > 0 && m$col %in% names(src_df) &&
+            is.data.frame(tgt_df) && nrow(tgt_df) > 0) {
+          mat <- rebuild_forward_matrix_by_name(
+            source_df = src_df, linked_col = m$col, target_df = tgt_df,
+            element_confidence_col = "Confidence")
+          if (any(nzchar(mat))) {
+            isa_data$adjacency_matrices[[mk]]   <- mat
+            isa_data$user_edited_matrices[[mk]] <- matrix(
+              FALSE, nrow(mat), ncol(mat), dimnames = dimnames(mat))
             fell_back <- TRUE
           }
         }

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-isa-import-handler.R
@@ -214,3 +214,68 @@ test_that("import of an unrecognized workbook is a clean no-op (state unchanged)
       expect_length(rv$es_panel_ids, 0)
   })
 })
+
+test_that("legacy import gate: empty forward matrices + label-form LinkedX + duplicate IDs recover edges by NAME", {
+  # Reproduces the real ISA_Export_20260525.xlsx pathology (v1.13.1 export):
+  #  - forward Matrix_* present but EMPTY; only gb_d carries faithful edges
+  #  - forward links live in LinkedX columns in LABEL form ("ID: Name")
+  #  - Marine_Processes has a DUPLICATE id (MPF005 used twice, distinct names)
+  source_for_test("functions/isa_export_helpers.R")
+  source_for_test("functions/standard_entry_excel_import.R")
+  source_for_test("functions/matrix_from_linked.R")
+
+  isa <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001: Food", Mechanism = "", Confidence = "High",
+                                    stringsAsFactors = FALSE),
+    # DUPLICATE id MPF005 across two distinct elements (the old positional-ID bug)
+    marine_processes = data.frame(
+      ID = c("MPF005", "MPF005"),
+      Name = c("Fish biomass", "Biodiversity richness"),
+      Type = "", Description = "", LinkedES = c("ES001: Fish", "ES001: Fish"),
+      Mechanism = "", Spatial = "", stringsAsFactors = FALSE),
+    pressures = data.frame(ID = "P001", Name = "Overfishing", Type = "", Description = "",
+                           # label says MPF005 but the NAME points at "Biodiversity richness"
+                           LinkedMPF = "MPF005: Biodiversity richness",
+                           Intensity = "", Spatial = "", Temporal = "", stringsAsFactors = FALSE),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character()),
+    adjacency_matrices = list(
+      es_gb = matrix("", 1, 1, dimnames = list("ES001", "GB001")),         # present but EMPTY
+      gb_d  = matrix("+Strong:3", 1, 1, dimnames = list("GB001", "D001"))  # faithful, populated
+    )
+  )
+  wb <- openxlsx::createWorkbook(); write_isa_element_sheets(wb, isa, include_adjacency = TRUE)
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  testServer(isa_data_entry_server,
+    args = list(project_data_reactive = reactiveVal(init_session_data()),
+                i18n = fake_i18n, parent_session = NULL), {
+      session$setInputs(import_file = data.frame(
+        name = "legacy.xlsx", size = 1, type = "", datapath = tmp, stringsAsFactors = FALSE))
+      session$setInputs(import_data = 1)
+      session$flushReact()
+      rv <- session$getReturned()()
+
+      # All elements loaded; the duplicate MPF id is reconciled to two unique ids.
+      expect_equal(nrow(rv$marine_processes), 2)
+      mpf_ids <- as.character(rv$marine_processes$ID)
+      expect_equal(length(unique(mpf_ids)), 2)
+
+      # gb_d (faithful) preserved exactly.
+      expect_equal(rv$adjacency_matrices$gb_d["GB001", "D001"], "+Strong:3")
+
+      # es_gb: present-but-empty matrix was rebuilt from LinkedGB (label "GB001: Food").
+      expect_true(nzchar(rv$adjacency_matrices$es_gb["ES001", "GB001"]))
+
+      # p_mpf: rebuilt from LinkedMPF, resolved BY NAME to "Biodiversity richness"
+      # (NOT the stale duplicate id MPF005 = "Fish biomass").
+      id_biodiv <- mpf_ids[rv$marine_processes$Name == "Biodiversity richness"]
+      id_fish   <- mpf_ids[rv$marine_processes$Name == "Fish biomass"]
+      pm <- rv$adjacency_matrices$p_mpf
+      expect_true(nzchar(pm["P001", id_biodiv]))    # edge on the correct element
+      expect_equal(pm["P001", id_fish], "")          # NOT on the stale-id element
+  })
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-linked-by-name.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-linked-by-name.R
@@ -1,0 +1,53 @@
+# tests/testthat/test-linked-by-name.R
+# Name-based recovery of legacy (v1.13.x) Standard Entry exports, where forward
+# connections live in label-form LinkedX columns ("ID: Name") and element IDs
+# may be duplicated (the old positional-ID bug). Resolving links by NAME keeps
+# edges attached to the correct element after duplicate-ID repair.
+source_for_test("functions/matrix_from_linked.R")
+
+test_that("resolve_linked_to_target_ids prefers NAME match over a stale duplicate ID", {
+  # marine_processes AFTER reconcile: the two original 'MPF005' rows now have
+  # distinct IDs; the name "Biodiversity richness" belongs to MPF019.
+  tgt <- data.frame(
+    ID   = c("MPF005", "MPF019"),
+    Name = c("Fish biomass", "Biodiversity richness"),
+    stringsAsFactors = FALSE
+  )
+  # A pressure's label still says "MPF005: Biodiversity richness" (stale ID).
+  expect_equal(resolve_linked_to_target_ids("MPF005: Biodiversity richness", tgt), "MPF019")
+})
+
+test_that("resolve_linked_to_target_ids falls back to bare-ID match", {
+  tgt <- data.frame(ID = c("GB001", "GB002"), Name = c("Food", "Energy"),
+                    stringsAsFactors = FALSE)
+  expect_equal(resolve_linked_to_target_ids("GB001", tgt), "GB001")           # bare id
+  expect_equal(resolve_linked_to_target_ids("GB002: Energy", tgt), "GB002")   # label, name+id agree
+})
+
+test_that("resolve_linked_to_target_ids handles multi-link, whitespace, case, and misses", {
+  tgt <- data.frame(ID = c("GB001", "GB002"), Name = c("Food", "Energy"),
+                    stringsAsFactors = FALSE)
+  expect_equal(resolve_linked_to_target_ids("GB001: Food|GB002: Energy", tgt), c("GB001", "GB002"))
+  expect_equal(resolve_linked_to_target_ids("ZZ9:  energy ", tgt), "GB002")   # name match wins despite junk id + ws/case
+  expect_equal(resolve_linked_to_target_ids("ZZ999: Nope", tgt), character(0))# unresolvable
+  expect_equal(resolve_linked_to_target_ids("", tgt), character(0))
+  expect_equal(resolve_linked_to_target_ids(NA, tgt), character(0))
+})
+
+test_that("rebuild_forward_matrix_by_name builds an ID-keyed matrix from label-form links", {
+  src <- data.frame(ID = c("P001", "P002"), Name = c("Overfishing", "Bycatch"),
+                    LinkedMPF = c("MPF005: Biodiversity richness", "MPF005: Fish biomass"),
+                    Confidence = c("High", NA), stringsAsFactors = FALSE)
+  tgt <- data.frame(ID = c("MPF005", "MPF019"), Name = c("Fish biomass", "Biodiversity richness"),
+                    stringsAsFactors = FALSE)
+  m <- rebuild_forward_matrix_by_name(src, "LinkedMPF", tgt)
+
+  expect_equal(dim(m), c(2, 2))
+  expect_equal(rownames(m), c("P001", "P002"))
+  expect_equal(colnames(m), c("MPF005", "MPF019"))
+  # P001 -> "Biodiversity richness" = MPF019 (NOT the stale MPF005); conf High
+  expect_equal(m["P001", "MPF019"], "+Medium:High")
+  expect_equal(m["P001", "MPF005"], "")
+  # P002 -> "Fish biomass" = MPF005; no Confidence -> default Medium
+  expect_equal(m["P002", "MPF005"], "+Medium:Medium")
+})


### PR DESCRIPTION
## Problem (found via two real user files)
A user reported two unreadable `data/` files:
- **`naujausias_20260525.rds`** — a valid v1.13.1 project wrapper but `data$isa_data` is an **empty list** (the old fork saved the shell without the ISA reactiveValues). **Nothing to recover** — reported to the user; no code change applies.
- **`ISA_Export_20260525.xlsx`** — the real model, but in legacy v1.13.x form that the L5 importer couldn't load:
  - forward connections live only in the **`LinkedX` columns in label form** (`"MPF001: Baltic fish biomass dynamics"`);
  - forward `Matrix_*` sheets are **present but empty** (only `gb_d` carries faithful edges);
  - element IDs are **duplicated** (the old positional-ID bug — 18 Marine Processes share 11 IDs, etc.).

The L5 importer's `LinkedX` fallback was **all-or-nothing** (it only ran when *no* `adjacency_matrices` existed). Because the file had `Matrix_*` sheets (just empty), the fallback never fired → the diagram came back **edgeless**.

## Fix
- **`functions/matrix_from_linked.R`** — `resolve_linked_to_target_ids()` + `rebuild_forward_matrix_by_name()`: resolve each link **by NAME first** (the legacy label carries it), so an edge attaches to the correct element *after* duplicate-ID repair; bare-ID fallback otherwise.
- **`apply_saved_isa()`** — the `LinkedX` fallback is now **per-transition**: rebuild any forward matrix that is absent or all-empty, while **keeping faithful matrices that have edges** (e.g. `gb_d`). Uses the name-based resolver.

## Validation on the real file
Reconcile repairs the duplicate IDs (MP 18→18, P 18→18, A 15→15, D 18→18 unique; elements preserved), then the forward chain recovers from `LinkedX`: **es_gb 5, mpf_es 18, p_mpf 18, a_p 15, d_a 18** edges (faithful had 0 each) + faithful **gb_d 41** → **79 elements, 115 edges** (was edgeless forward). Name resolution verified correct on real labels.

## Tests
- `test-linked-by-name.R` — resolver units incl. the key case: a label with a **stale duplicate ID** resolves to the right element **by name**.
- `test-isa-import-handler.R` — new **legacy-import gate**: synthetic fixture (empty forward matrix + faithful `gb_d` + label-form `LinkedX` + duplicate `MPF005`) driven through the real import handler; asserts the edge lands on "Biodiversity richness" (not the stale `MPF005` "Fish biomass"), `gb_d` preserved, empty `es_gb` rebuilt.
- Backward-compatible: faithful round-trip / replace / characterization / `matrix_from_linked` (20) all still green.

Note: the user's real `.xlsx`/`.rds` are **not** committed (synthetic fixture replicates the pathology deterministically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)