### PR TITLE
feat: sidebar Import Data menu accepts Standard Entry exports (shared recovery)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
+++ b/MarineSABRES_SES_Shiny/functions/standard_entry_excel_import.R
@@ -83,3 +83,93 @@ read_standard_entry_workbook <- function(path) {
 
   out
 }
+
+# ---------------------------------------------------------------------------
+# recover_isa_data(): the pure recovery pipeline
+# ---------------------------------------------------------------------------
+# Turns a raw saved_isa (from read_standard_entry_workbook OR a saved project)
+# into a clean, app-ready isa_data: reconciles each element category to unique
+# IDs (repairing the old positional-ID duplicates), then for each forward
+# transition rebuilds an absent/empty matrix from the per-category LinkedX
+# column — resolving links BY NAME so edges survive duplicate-ID repair —
+# while KEEPING faithful matrices that already carry edges (e.g. gb_d).
+#
+# Single source of truth shared by the Standard Entry module's apply_saved_isa()
+# (in-page Import button + project-load) and the sidebar Import Data menu, so the
+# two import doors recover identically. Pure: no Shiny/reactives. Requires the
+# globals ELEMENT_ID_PREFIX (constants.R), reconcile_loaded_element_ids /
+# new_stable_id_store (data_structure.R), rebuild_forward_matrix_by_name
+# (matrix_from_linked.R).
+#
+# @return list(elements, panel_ids, adjacency_matrices, user_edited_matrices,
+#   repaired, any_rows_in, any_panel_ids_out, fell_back)
+recover_isa_data <- function(saved_isa, id_store = NULL) {
+  if (is.null(id_store)) id_store <- new_stable_id_store()
+
+  id_load_map <- list(
+    goods_benefits     = list(prefix = ELEMENT_ID_PREFIX$welfare,    panel = "gb_panel_ids"),
+    ecosystem_services = list(prefix = ELEMENT_ID_PREFIX$impacts,    panel = "es_panel_ids"),
+    marine_processes   = list(prefix = ELEMENT_ID_PREFIX$states,     panel = "mpf_panel_ids"),
+    pressures          = list(prefix = ELEMENT_ID_PREFIX$pressures,  panel = "p_panel_ids"),
+    activities         = list(prefix = ELEMENT_ID_PREFIX$activities, panel = "a_panel_ids"),
+    drivers            = list(prefix = ELEMENT_ID_PREFIX$drivers,    panel = "d_panel_ids")
+  )
+
+  elements <- list(); panel_ids <- list()
+  repaired <- FALSE; any_rows_in <- FALSE; any_panel_ids_out <- FALSE
+  for (k in names(id_load_map)) {
+    df <- saved_isa[[k]]
+    if (is.data.frame(df) && nrow(df) > 0) {
+      any_rows_in <- TRUE
+      rec <- reconcile_loaded_element_ids(df, id_load_map[[k]]$prefix, id_store)
+      elements[[k]] <- rec$df
+      pids <- as.character(rec$df$ID)
+      panel_ids[[id_load_map[[k]]$panel]] <- pids
+      if (length(pids) > 0 && any(nzchar(pids))) any_panel_ids_out <- TRUE
+      if (isTRUE(rec$repaired)) repaired <- TRUE
+    } else {
+      elements[[k]] <- if (is.data.frame(df)) df else data.frame()
+      panel_ids[[id_load_map[[k]]$panel]] <- character(0)
+    }
+  }
+
+  am <- if (!is.null(saved_isa$adjacency_matrices)) saved_isa$adjacency_matrices else list()
+  ue <- list()
+  fell_back <- FALSE
+  linked_map <- list(
+    es_gb  = list(src = "ecosystem_services", col = "LinkedGB",  tgt = "goods_benefits"),
+    mpf_es = list(src = "marine_processes",   col = "LinkedES",  tgt = "ecosystem_services"),
+    p_mpf  = list(src = "pressures",          col = "LinkedMPF", tgt = "marine_processes"),
+    a_p    = list(src = "activities",         col = "LinkedP",   tgt = "pressures"),
+    d_a    = list(src = "drivers",            col = "LinkedA",   tgt = "activities")
+  )
+  for (mk in names(linked_map)) {
+    m <- linked_map[[mk]]
+    src_df <- elements[[m$src]]; tgt_df <- elements[[m$tgt]]
+    existing <- am[[mk]]
+    has_edges <- is.matrix(existing) && any(nzchar(existing) & !is.na(existing))
+    if (!has_edges &&
+        is.data.frame(src_df) && nrow(src_df) > 0 && m$col %in% names(src_df) &&
+        is.data.frame(tgt_df) && nrow(tgt_df) > 0) {
+      mat <- rebuild_forward_matrix_by_name(
+        source_df = src_df, linked_col = m$col, target_df = tgt_df,
+        element_confidence_col = "Confidence")
+      if (any(nzchar(mat))) {
+        am[[mk]] <- mat
+        ue[[mk]] <- matrix(FALSE, nrow(mat), ncol(mat), dimnames = dimnames(mat))
+        fell_back <- TRUE
+      }
+    }
+  }
+
+  list(
+    elements = elements,
+    panel_ids = panel_ids,
+    adjacency_matrices = am,
+    user_edited_matrices = ue,
+    repaired = repaired,
+    any_rows_in = any_rows_in,
+    any_panel_ids_out = any_panel_ids_out,
+    fell_back = fell_back
+  )
+}

--- a/MarineSABRES_SES_Shiny/modules/import_data_module.R
+++ b/MarineSABRES_SES_Shiny/modules/import_data_module.R
@@ -253,6 +253,40 @@ import_data_server <- function(id, project_data_reactive, i18n, parent_session =
 
         if (is.null(sheets)) return(NULL)
 
+        # Standard Entry export? (per-category element sheets and/or Matrix_*
+        # sheets — a DIFFERENT format from the Elements/Connections importer
+        # below). Route it through the Standard Entry reader + the shared
+        # recovery pipeline, then import directly, so this menu accepts files
+        # exported from the Standard Entry page — not just edge-list workbooks.
+        .se_sheets <- c("Goods_Benefits", "Ecosystem_Services", "Marine_Processes",
+                        "Pressures", "Activities", "Drivers")
+        .is_se_export <- (any(.se_sheets %in% sheets) || any(startsWith(sheets, "Matrix_"))) &&
+                         !(("Elements" %in% sheets) && ("Connections" %in% sheets))
+        if (.is_se_export) {
+          saved <- read_standard_entry_workbook(file_path)   # may signal se_import_not_recognized -> outer catch
+          recov <- recover_isa_data(saved)
+          isa_for_import <- recov$elements
+          isa_for_import$adjacency_matrices <- recov$adjacency_matrices
+          n_el <- sum(vapply(recov$elements,
+                             function(d) if (is.data.frame(d)) nrow(d) else 0L, integer(1)))
+          n_ed <- sum(vapply(recov$adjacency_matrices,
+                             function(m) if (is.matrix(m)) sum(nzchar(m) & !is.na(m)) else 0L, integer(1)))
+          if (n_el == 0L) {
+            showNotification(i18n$t("modules.isa.data_entry.common.import_not_recognized"),
+                             type = "error", duration = 8)
+            return(NULL)
+          }
+          perform_import(isa_for_import, n_el, n_ed)   # sets project_data + CLD, navigates
+          if (isTRUE(recov$fell_back)) {
+            showNotification(i18n$t("modules.isa.data_entry.common.import_links_defaulted"),
+                             type = "warning", duration = 10)
+          }
+          if (!is.null(parent_session)) {
+            updateTabItems(parent_session, "sidebar_menu", "cld_viz")
+          }
+          return(NULL)
+        }
+
         if (!("Elements" %in% sheets) || !("Connections" %in% sheets)) {
           showNotification(
             i18n$t("modules.import.data.missing_sheets"),

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -273,71 +273,29 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
     #   canonicalizes IDs and sets *_panel_ids. Shared by the project-load
     #   observer and the Excel import handler. Caller sets data_initialized().
     apply_saved_isa <- function(saved_isa) {
+      # Copies counters, loop_connections, case_info, bot_data, and the saved
+      # matrices into the module reactiveValues (element dfs get lowercased here
+      # for the table view, then overwritten below with the reconciled versions).
       load_isa_elements_from_saved(isa_data, saved_isa)
 
-      id_load_map <- list(
-        goods_benefits     = list(prefix = ELEMENT_ID_PREFIX$welfare,    panel = "gb_panel_ids"),
-        ecosystem_services = list(prefix = ELEMENT_ID_PREFIX$impacts,    panel = "es_panel_ids"),
-        marine_processes   = list(prefix = ELEMENT_ID_PREFIX$states,     panel = "mpf_panel_ids"),
-        pressures          = list(prefix = ELEMENT_ID_PREFIX$pressures,  panel = "p_panel_ids"),
-        activities         = list(prefix = ELEMENT_ID_PREFIX$activities, panel = "a_panel_ids"),
-        drivers            = list(prefix = ELEMENT_ID_PREFIX$drivers,    panel = "d_panel_ids")
-      )
-      any_repaired <- FALSE
-      any_rows_in <- FALSE
-      any_panel_ids_out <- FALSE
-      # NB: reconcile the RAW saved df (uppercase ID), NOT the lowercased copy load_isa_elements_from_saved writes for the table view — keying on lowercase 'id' was the L6 'no elements' bug.
-      for (key in names(id_load_map)) {
-        saved_df <- saved_isa[[key]]
-        if (is.data.frame(saved_df) && nrow(saved_df) > 0) {
-          any_rows_in <- TRUE
-          rec <- reconcile_loaded_element_ids(saved_df, id_load_map[[key]]$prefix, id_store)
-          isa_data[[key]] <- rec$df
-          panel_ids <- as.character(rec$df$ID)
-          isa_data[[id_load_map[[key]]$panel]] <- panel_ids
-          if (length(panel_ids) > 0 && any(nzchar(panel_ids))) any_panel_ids_out <- TRUE
-          if (isTRUE(rec$repaired)) any_repaired <- TRUE
-        } else {
-          isa_data[[id_load_map[[key]]$panel]] <- character(0)
-        }
+      # Reconcile element IDs (repairing legacy duplicates) and rebuild empty
+      # forward matrices from label-form LinkedX (resolved BY NAME) via the
+      # shared pure pipeline — the SAME recovery the sidebar Import Data menu
+      # uses, so both import doors behave identically.
+      # NB: recover_isa_data reconciles the RAW saved df (uppercase ID), NOT the
+      # lowercased copy load_isa_elements_from_saved just wrote — keying on
+      # lowercase 'id' was the L6 'no elements' bug.
+      rec <- recover_isa_data(saved_isa, id_store)
+      for (k in names(rec$elements)) {
+        if (nrow(rec$elements[[k]]) > 0) isa_data[[k]] <- rec$elements[[k]]
       }
-      # Per-transition LinkedX fallback. For EACH forward transition, if its
-      # faithful Matrix_* matrix is absent or has NO non-empty cells, rebuild it
-      # from the per-category LinkedX column. Legacy v1.13.x exports stored
-      # forward links only in the LinkedX columns (label form "ID: Name") and
-      # exported EMPTY forward matrices, so an all-or-nothing gate would leave
-      # the diagram edgeless whenever any one matrix (e.g. gb_d) had data.
-      # Links resolve by NAME first (robust to the old duplicate-ID bug), so an
-      # edge attaches to the correct element after reconcile renames duplicates.
-      # Faithful matrices that DO carry edges (e.g. gb_d) are kept as-is.
-      fell_back <- FALSE
-      linked_map <- list(
-        es_gb  = list(src = "ecosystem_services", col = "LinkedGB",  tgt = "goods_benefits"),
-        mpf_es = list(src = "marine_processes",   col = "LinkedES",  tgt = "ecosystem_services"),
-        p_mpf  = list(src = "pressures",          col = "LinkedMPF", tgt = "marine_processes"),
-        a_p    = list(src = "activities",         col = "LinkedP",   tgt = "pressures"),
-        d_a    = list(src = "drivers",            col = "LinkedA",   tgt = "activities")
-      )
-      for (mk in names(linked_map)) {
-        m <- linked_map[[mk]]
-        src_df   <- isa_data[[m$src]]
-        tgt_df   <- isa_data[[m$tgt]]
-        existing <- isa_data$adjacency_matrices[[mk]]
-        has_edges <- is.matrix(existing) && any(nzchar(existing) & !is.na(existing))
-        if (!has_edges &&
-            is.data.frame(src_df) && nrow(src_df) > 0 && m$col %in% names(src_df) &&
-            is.data.frame(tgt_df) && nrow(tgt_df) > 0) {
-          mat <- rebuild_forward_matrix_by_name(
-            source_df = src_df, linked_col = m$col, target_df = tgt_df,
-            element_confidence_col = "Confidence")
-          if (any(nzchar(mat))) {
-            isa_data$adjacency_matrices[[mk]]   <- mat
-            isa_data$user_edited_matrices[[mk]] <- matrix(
-              FALSE, nrow(mat), ncol(mat), dimnames = dimnames(mat))
-            fell_back <- TRUE
-          }
-        }
-      }
+      for (p in names(rec$panel_ids)) isa_data[[p]] <- rec$panel_ids[[p]]
+      isa_data$adjacency_matrices <- rec$adjacency_matrices
+      isa_data$user_edited_matrices[names(rec$user_edited_matrices)] <- rec$user_edited_matrices
+      any_repaired      <- rec$repaired
+      any_rows_in       <- rec$any_rows_in
+      any_panel_ids_out <- rec$any_panel_ids_out
+      fell_back         <- rec$fell_back
 
       if (any_repaired) {
         showNotification(i18n$t("modules.isa.data_entry.common.ids_repaired_on_load"),

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-import-data-se-format.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-import-data-se-format.R
@@ -1,0 +1,81 @@
+# tests/testthat/test-import-data-se-format.R
+# The sidebar "Import Data" menu (generic Elements/Connections importer) must
+# ALSO accept a Standard Entry export (per-category element sheets + Matrix_*),
+# routing it through read_standard_entry_workbook + recover_isa_data so it loads
+# with edges recovered by name despite the legacy duplicate-ID / empty-forward
+# pathology.
+source_for_test("functions/isa_export_helpers.R")
+source_for_test("functions/standard_entry_excel_import.R")
+source_for_test("functions/matrix_from_linked.R")
+source_for_test("modules/import_data_module.R")
+import_data_server <- get("import_data_server", envir = .GlobalEnv)  # defeat any stub
+
+.idse_i18n <- list(t = function(x, ...) x)
+
+test_that("Import Data menu loads a Standard Entry export (legacy pathology) with recovered edges", {
+  isa <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001: Food", Mechanism = "", Confidence = "High",
+                                    stringsAsFactors = FALSE),
+    marine_processes = data.frame(
+      ID = c("MPF005", "MPF005"), Name = c("Fish biomass", "Biodiversity richness"),
+      Type = "", Description = "", LinkedES = c("ES001: Fish", "ES001: Fish"),
+      Mechanism = "", Spatial = "", stringsAsFactors = FALSE),
+    pressures = data.frame(ID = "P001", Name = "Overfishing", Type = "", Description = "",
+                           LinkedMPF = "MPF005: Biodiversity richness",
+                           Intensity = "", Spatial = "", Temporal = "", stringsAsFactors = FALSE),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = "D001", Name = "Demand", Type = "", Description = "",
+                         LinkedA = "", Trend = "", Controllability = "", stringsAsFactors = FALSE),
+    adjacency_matrices = list(
+      es_gb = matrix("", 1, 1, dimnames = list("ES001", "GB001")),         # present but empty
+      gb_d  = matrix("+Strong:3", 1, 1, dimnames = list("GB001", "D001"))  # faithful
+    )
+  )
+  wb <- openxlsx::createWorkbook(); write_isa_element_sheets(wb, isa, include_adjacency = TRUE)
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  pdr <- reactiveVal(init_session_data())
+  testServer(import_data_server,
+    args = list(project_data_reactive = pdr, i18n = .idse_i18n,
+                parent_session = NULL, event_bus = NULL), {
+      session$setInputs(excel_file = data.frame(
+        name = "ISA_Export.xlsx", size = 1, type = "", datapath = tmp, stringsAsFactors = FALSE))
+      session$flushReact()
+
+      pd <- pdr()
+      isa_loaded <- pd$data$isa_data
+      # duplicate MPF id reconciled to two unique elements
+      expect_equal(nrow(isa_loaded$marine_processes), 2)
+      expect_equal(length(unique(isa_loaded$marine_processes$ID)), 2)
+      # faithful gb_d preserved
+      expect_equal(isa_loaded$adjacency_matrices$gb_d["GB001", "D001"], "+Strong:3")
+      # forward edges recovered (es_gb rebuilt from label LinkedGB)
+      expect_true(any(nzchar(isa_loaded$adjacency_matrices$es_gb)))
+      # CLD built with edges -> the diagram won't be empty
+      expect_gt(nrow(pd$data$cld$edges), 0)
+      expect_identical(pd$data$metadata$data_source, "excel_import")
+  })
+})
+
+test_that("Import Data menu still rejects a non-Standard-Entry, non-Elements/Connections workbook", {
+  wb <- openxlsx::createWorkbook()
+  openxlsx::addWorksheet(wb, "RandomSheet")
+  openxlsx::writeData(wb, "RandomSheet", data.frame(foo = 1, bar = 2))
+  tmp <- tempfile(fileext = ".xlsx"); openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  pdr <- reactiveVal(init_session_data())
+  testServer(import_data_server,
+    args = list(project_data_reactive = pdr, i18n = .idse_i18n,
+                parent_session = NULL, event_bus = NULL), {
+      session$setInputs(excel_file = data.frame(
+        name = "bad.xlsx", size = 1, type = "", datapath = tmp, stringsAsFactors = FALSE))
+      session$flushReact()
+      # nothing loaded (no isa_data elements committed)
+      pd <- pdr()
+      gb <- pd$data$isa_data$goods_benefits
+      expect_true(is.null(gb) || nrow(gb) == 0)
+  })
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-recover-isa-data.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-recover-isa-data.R
@@ -1,0 +1,67 @@
+# tests/testthat/test-recover-isa-data.R
+# Pure recovery used by BOTH the Standard Entry import handler and the sidebar
+# Import Data menu: reconcile duplicate IDs + rebuild empty forward matrices
+# from label-form LinkedX (resolved by NAME) + keep faithful matrices.
+source_for_test("functions/data_structure.R")        # reconcile_loaded_element_ids, new_stable_id_store
+source_for_test("functions/matrix_from_linked.R")    # resolve/rebuild helpers
+source_for_test("functions/standard_entry_excel_import.R")  # recover_isa_data
+
+test_that("recover_isa_data reconciles dup IDs, rebuilds forward edges by name, keeps faithful matrices", {
+  saved <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", Type = "", Description = "",
+                                Stakeholder = "", Importance = "", Trend = "", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", Type = "", Description = "",
+                                    LinkedGB = "GB001: Food", Mechanism = "", Confidence = "High",
+                                    stringsAsFactors = FALSE),
+    marine_processes = data.frame(
+      ID = c("MPF005", "MPF005"), Name = c("Fish biomass", "Biodiversity richness"),
+      Type = "", Description = "", LinkedES = c("ES001: Fish", "ES001: Fish"),
+      Mechanism = "", Spatial = "", stringsAsFactors = FALSE),
+    pressures = data.frame(ID = "P001", Name = "Overfishing", Type = "", Description = "",
+                           LinkedMPF = "MPF005: Biodiversity richness",
+                           Intensity = "", Spatial = "", Temporal = "", stringsAsFactors = FALSE),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character()),
+    adjacency_matrices = list(
+      es_gb = matrix("", 1, 1, dimnames = list("ES001", "GB001")),          # present but empty
+      gb_d  = matrix("+Strong:3", 1, 1, dimnames = list("GB001", "D001"))   # faithful
+    )
+  )
+
+  rec <- recover_isa_data(saved)
+
+  # duplicate MPF id reconciled to two unique ids; names preserved
+  expect_equal(nrow(rec$elements$marine_processes), 2)
+  expect_equal(length(unique(rec$elements$marine_processes$ID)), 2)
+  expect_true(rec$repaired)
+  expect_setequal(rec$panel_ids$mpf_panel_ids, as.character(rec$elements$marine_processes$ID))
+
+  # faithful gb_d preserved; empty es_gb rebuilt from label-form LinkedGB
+  expect_equal(rec$adjacency_matrices$gb_d["GB001", "D001"], "+Strong:3")
+  expect_true(nzchar(rec$adjacency_matrices$es_gb["ES001", "GB001"]))
+  expect_true(rec$fell_back)
+
+  # p_mpf rebuilt resolving BY NAME -> "Biodiversity richness", not stale MPF005="Fish biomass"
+  mp <- rec$elements$marine_processes
+  id_biodiv <- mp$ID[mp$Name == "Biodiversity richness"]
+  id_fish   <- mp$ID[mp$Name == "Fish biomass"]
+  pm <- rec$adjacency_matrices$p_mpf
+  expect_true(nzchar(pm["P001", id_biodiv]))
+  expect_equal(pm["P001", id_fish], "")
+})
+
+test_that("recover_isa_data leaves a clean (no-dup, faithful) project unchanged", {
+  saved <- list(
+    goods_benefits = data.frame(ID = "GB001", Name = "Food", stringsAsFactors = FALSE),
+    ecosystem_services = data.frame(ID = "ES001", Name = "Fish", LinkedGB = "GB001", stringsAsFactors = FALSE),
+    marine_processes = data.frame(ID = character(), Name = character()),
+    pressures = data.frame(ID = character(), Name = character()),
+    activities = data.frame(ID = character(), Name = character()),
+    drivers = data.frame(ID = character(), Name = character()),
+    adjacency_matrices = list(es_gb = matrix("+High:High", 1, 1, dimnames = list("ES001", "GB001")))
+  )
+  rec <- recover_isa_data(saved)
+  expect_false(rec$repaired)
+  expect_false(rec$fell_back)                       # es_gb already had an edge
+  expect_equal(rec$adjacency_matrices$es_gb["ES001", "GB001"], "+High:High")
+})


### PR DESCRIPTION
## Why
A user kept trying to load their Standard-Entry Excel export from the **sidebar "Import Data" menu** and it was rejected — because that menu is the *generic* importer that only accepts `Elements`+`Connections` sheets. The Standard-Entry export (`Goods_Benefits`/…/`Matrix_*` sheets) is read by the *in-page* Standard Entry Import button (PR #38), but not the sidebar menu. Two controls named "Import Data", one importer — a UX trap.

## What
The sidebar Import Data menu now **auto-detects** a Standard Entry export and routes it through the same reader + recovery pipeline; the `Elements`/`Connections` path is unchanged; unrecognized workbooks are still rejected. **Both doors now work and recover identically.**

- **`recover_isa_data()`** (new, pure, in `standard_entry_excel_import.R`) — the single source of truth for recovery: reconcile element IDs (repair legacy duplicates) + per-transition rebuild of empty/absent forward matrices from label-form `LinkedX` (resolved **by name**, robust to duplicate-ID repair) + keep faithful matrices (e.g. `gb_d`).
- **`apply_saved_isa()`** (Standard Entry module) refactored to delegate to `recover_isa_data()` — behaviour-preserving (no drift between the two import paths).
- **`import_data_module`** — on upload, if the file is a Standard Entry export, `read_standard_entry_workbook` → `recover_isa_data` → `perform_import` (builds the CLD from the recovered matrices) → navigate to CLD Visualization.

## Tests
- `test-recover-isa-data.R` — pure recovery: reconciles a duplicate `MPF005`, rebuilds empty `es_gb` from label-form `LinkedGB`, keeps faithful `gb_d`, resolves `p_mpf` **by name** to the correct element; and a clean project is left unchanged.
- `test-import-data-se-format.R` — the **menu** loads the legacy-pathology fixture: `project_data` gets the recovered `isa_data`, `gb_d` faithful, forward edges recovered, `cld$edges` non-empty; junk workbooks still rejected.
- Backward-compatible: Standard Entry handler/characterization/gate (24), `matrix_from_linked` (20), name-resolver (14) all green. **Full suite 7387 / 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Standard Entry format Excel workbooks with automatic data recovery and ID reconciliation.

* **Improvements**
  * Enhanced handling of legacy and duplicate identifiers during data import.
  * Automatic adjacency matrix reconstruction from imported linked element references.

* **Tests**
  * Added comprehensive test coverage for Standard Entry imports and data recovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->