### PR TITLE
fix(cld): merge-confirm modal ns() crash + post-merge re-render (re-applies #11)

### DIFF
--- a/MarineSABRES_SES_Shiny/modules/cld_visualization_module.R
+++ b/MarineSABRES_SES_Shiny/modules/cld_visualization_module.R
@@ -1073,14 +1073,14 @@ cld_viz_server <- function(id, project_data_reactive, i18n, event_bus = NULL) {
         title = i18n$t("modules.cld.visualization.merge_title"),
         p(i18n$t("modules.cld.visualization.merge_description")),
         radioButtons(
-          inputId = ns("merge_primary"),
+          inputId = session$ns("merge_primary"),
           label = i18n$t("modules.cld.visualization.merge_keep_label"),
           choices = label_choices,
           selected = selected_rows$id[1]
         ),
         footer = tagList(
           modalButton(i18n$t("common.buttons.cancel")),
-          actionButton(ns("merge_confirm"), i18n$t("common.buttons.confirm"),
+          actionButton(session$ns("merge_confirm"), i18n$t("common.buttons.confirm"),
                        class = "btn-primary")
         ),
         easyClose = TRUE
@@ -1116,13 +1116,14 @@ cld_viz_server <- function(id, project_data_reactive, i18n, event_bus = NULL) {
       rv$nodes <- result$nodes
       rv$edges <- result$edges
 
-      # Remove secondaries from the visNetwork canvas
-      visNetworkProxy(session$ns("network")) %>%
-        visRemoveNodes(id = result$removed_ids)
-
-      # Re-render edges (rewiring may have dropped/changed them)
-      visNetworkProxy(session$ns("network")) %>%
-        visUpdateEdges(edges = rv$edges)
+      # Force a full re-render rather than proxy-patching the canvas. Proxy
+      # updates can't reliably reconcile with merge_cld_nodes()'s edge ID
+      # renumbering (seq_len after dedupe): visUpdateEdges only inserts/updates
+      # by id and never removes, so any old vis.js edge whose id is higher than
+      # the new max becomes a stale duplicate / phantom edge that visually
+      # disconnects parts of the graph. A re-render rebuilds from rv$nodes /
+      # rv$edges, which are the source of truth.
+      rv$layout_render_trigger <- rv$layout_render_trigger + 1
 
       # Sync + propagate to isa_data for analyses
       isolate({

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-merge-cld-nodes.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-merge-cld-nodes.R
@@ -166,3 +166,42 @@ test_that("merge_cld_nodes distinguishes edges with NA labels from polarity-matc
   result <- merge_cld_nodes(nodes, edges, c("D_1", "D_2"), "D_1")
   expect_equal(nrow(result$edges), 2)  # both preserved
 })
+
+test_that("merge_cld_nodes leaves no node disconnected when its only edge survives dedupe", {
+  # REGRESSION: a downstream node's only inbound edges were two parallel
+  # connections from two soon-to-be-merged secondaries. After rewire + dedupe,
+  # exactly one edge from the primary must remain — otherwise the downstream
+  # node ends up orphaned in rv$nodes/rv$edges.
+  skip_if_not(exists("merge_cld_nodes", mode = "function"),
+              "merge_cld_nodes not available")
+  nodes <- data.frame(
+    id = c("P_5", "P_6", "MPF_1"),
+    label = c("p5", "p6", "mpf1"),
+    group = c("Pressures", "Pressures", "Marine Processes & Functioning"),
+    stringsAsFactors = FALSE
+  )
+  edges <- data.frame(
+    id = 1:2,
+    from = c("P_5", "P_6"),
+    to   = c("MPF_1", "MPF_1"),
+    label = c("-", "-"),
+    stringsAsFactors = FALSE
+  )
+  result <- merge_cld_nodes(nodes, edges, c("P_5", "P_6"), "P_5")
+  expect_equal(nrow(result$edges), 1)
+  expect_true("MPF_1" %in% c(result$edges$from, result$edges$to))
+  # MPF_1 must still be connected after merge — i.e., not an island
+  connected <- unique(c(result$edges$from, result$edges$to))
+  expect_true(all(result$nodes$id %in% connected))
+})
+
+test_that("merge_cld_nodes renumbers edge ids contiguously from 1 (callers depend on this)", {
+  # The cld_visualization module assumes edge ids are seq_len after merge:
+  # the edge-counter for new-edge creation uses nrow(rv$edges), so any gap
+  # would let a new edge collide with an existing id. Lock that contract.
+  skip_if_not(exists("merge_cld_nodes", mode = "function"),
+              "merge_cld_nodes not available")
+  fx <- make_fixture()
+  result <- merge_cld_nodes(fx$nodes, fx$edges, c("D_1", "D_2"), "D_1")
+  expect_equal(result$edges$id, seq_len(nrow(result$edges)))
+})


### PR DESCRIPTION
Re-applies the genuine fix from **#11** (which is unmergeable — its branch shares no common ancestor with current main, and it bundled ~2994 lines of unrelated WP5 docs) cleanly onto current `main`.

## Live bugs fixed (still present on main)
1. **Crash:** the merge-confirm modal built `ns("merge_primary")` / `ns("merge_confirm")` inside the **server** (`moduleServer`), where `ns` isn't defined (only `session$ns` is) — clicking *Merge* on selected CLD nodes threw `could not find function "ns"`. → `session$ns()`.
2. **Phantom edges:** post-merge it proxy-patched the canvas with `visRemoveNodes` + `visUpdateEdges`. `visUpdateEdges` only inserts/updates by id and never removes, so after `merge_cld_nodes()` renumbers edge ids to `seq_len` any old vis.js edge with a higher id lingered as a stale/phantom edge. → bump `rv$layout_render_trigger` for a full re-render from `rv$nodes`/`rv$edges` (the module's existing idiom).

## Tests
2 regression tests added to `test-merge-cld-nodes.R` (orphan-node-after-dedupe; edge-id contiguity contract). Suite: `test-merge-cld-nodes.R` 26/0, `test-cld-visualization-module.R` 8/0.

Closes the intent of #11 (recommend closing #11 as superseded by this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)