### PR TITLE
feat(isa): N:M multi-select forward links in Standard Entry

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/isa_form_builders.R
+++ b/MarineSABRES_SES_Shiny/functions/isa_form_builders.R
@@ -34,7 +34,16 @@ build_entry_panel_ui <- function(ns, prefix, current_id, fields, i18n) {
   build_field <- function(field) {
     input_id <- ns(paste0(prefix, "_", field$id, "_", current_id))
     if (identical(field$type, "select")) {
-      column(field$width, selectInput(input_id, field$label, choices = field$choices))
+      if (isTRUE(field$multiple)) {
+        # Multi-select forward link (N:M): an element can pick many targets in
+        # one panel. Drop the leading "" placeholder — an empty selection (no
+        # picks) already means "no link", so a blank option is meaningless here.
+        choices <- field$choices[nzchar(field$choices)]
+        column(field$width,
+               selectInput(input_id, field$label, choices = choices, multiple = TRUE))
+      } else {
+        column(field$width, selectInput(input_id, field$label, choices = field$choices))
+      }
     } else {
       column(field$width, textInput(input_id, field$label,
                                      placeholder = if (!is.null(field$placeholder)) field$placeholder else ""))
@@ -153,7 +162,7 @@ isa_fields_es <- function(i18n, linked_choices) {
     list(id = "desc", type = "text", label = i18n$t("common.labels.description"),
          width = 6),
     list(id = "linkedgb", type = "select", label = i18n$t("modules.isa.data_entry.common.linked_to_gb"),
-         width = 3, choices = linked_choices),
+         width = 3, choices = linked_choices, multiple = TRUE),
     list(id = "mechanism", type = "text", label = i18n$t("modules.isa.data_entry.common.mechanism"),
          width = 3),
     list(id = "confidence", type = "select", label = i18n$t("modules.isa.data_entry.common.confidence"),
@@ -174,7 +183,7 @@ isa_fields_mpf <- function(i18n, linked_choices) {
     list(id = "desc", type = "text", label = i18n$t("common.labels.description"),
          width = 6),
     list(id = "linkedes", type = "select", label = i18n$t("modules.isa.data_entry.common.linked_to_es"),
-         width = 3, choices = linked_choices),
+         width = 3, choices = linked_choices, multiple = TRUE),
     list(id = "mechanism", type = "text", label = i18n$t("modules.isa.data_entry.common.mechanism"),
          width = 3),
     list(id = "spatial", type = "text", label = i18n$t("modules.isa.data_entry.common.spatial_scale"),
@@ -195,7 +204,7 @@ isa_fields_p <- function(i18n, linked_choices) {
     list(id = "desc", type = "text", label = i18n$t("common.labels.description"),
          width = 6),
     list(id = "linkedmpf", type = "select", label = i18n$t("modules.isa.data_entry.common.linked_to_mpf"),
-         width = 3, choices = linked_choices),
+         width = 3, choices = linked_choices, multiple = TRUE),
     list(id = "intensity", type = "select", label = i18n$t("modules.isa.data_entry.common.intensity"),
          width = 3, choices = c("High", "Medium", "Low", "Unknown")),
     list(id = "spatial", type = "text", label = i18n$t("modules.isa.data_entry.common.spatial"),
@@ -218,7 +227,7 @@ isa_fields_a <- function(i18n, linked_choices) {
     list(id = "desc", type = "text", label = i18n$t("common.labels.description"),
          width = 6),
     list(id = "linkedp", type = "select", label = i18n$t("modules.isa.data_entry.common.linked_to_pressure"),
-         width = 3, choices = linked_choices),
+         width = 3, choices = linked_choices, multiple = TRUE),
     list(id = "scale", type = "select", label = i18n$t("modules.isa.data_entry.common.scale"),
          width = 3, choices = c("Local", "Regional", "National", "International")),
     list(id = "frequency", type = "select", label = i18n$t("modules.isa.data_entry.common.frequency"),
@@ -239,7 +248,7 @@ isa_fields_d <- function(i18n, linked_choices) {
     list(id = "desc", type = "text", label = i18n$t("common.labels.description"),
          width = 6),
     list(id = "linkeda", type = "select", label = i18n$t("modules.isa.data_entry.common.linked_to_activity"),
-         width = 3, choices = linked_choices),
+         width = 3, choices = linked_choices, multiple = TRUE),
     list(id = "trend", type = "select", label = i18n$t("modules.isa.data_entry.common.trend"),
          width = 3, choices = c("Increasing", "Stable", "Decreasing", "Cyclical", "Uncertain")),
     list(id = "control", type = "select", label = i18n$t("modules.isa.data_entry.common.controllability"),

--- a/MarineSABRES_SES_Shiny/functions/matrix_from_linked.R
+++ b/MarineSABRES_SES_Shiny/functions/matrix_from_linked.R
@@ -34,11 +34,19 @@ serialize_linked <- function(ids) {
 #' suffix from each segment, so it accepts BOTH the legacy label form and an
 #' already-bare/pipe-delimited id list — keeping previously-saved projects'
 #' links valid (see feedback #4).
-#' @param x select value: "", "GB001", "GB001: Food", or "GB001|GB002: Tourism"
+#' A multi-select widget hands this a character VECTOR of label-form values
+#' ("ES001: Fish", "ES002: Energy"); a legacy/stored value is a single,
+#' possibly '|'-delimited string. Splitting each element on '|' flattens both
+#' shapes to one id list. IDs are de-duplicated (first pick wins) so a node's
+#' repeated selection never inflates the link list — one element can carry many
+#' forward edges without duplicating the node (N:M).
+#' @param x select value(s): "", "GB001", "GB001: Food", "GB001|GB002: Tourism",
+#'   or c("GB001: Food", "GB002: Tourism") from a multi-select.
 #' @return single '|'-delimited string of bare IDs ("" when empty).
 linked_select_to_ids <- function(x) {
-  parts <- parse_linked(x)
-  ids <- trimws(sub(":.*$", "", parts))
+  if (is.null(x) || length(x) == 0) return("")
+  parts <- unlist(lapply(as.character(x), parse_linked), use.names = FALSE)
+  ids <- unique(trimws(sub(":.*$", "", parts)))
   serialize_linked(ids)
 }
 

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-isa-form-builders-multiselect.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-isa-form-builders-multiselect.R
@@ -1,0 +1,36 @@
+# tests/testthat/test-isa-form-builders-multiselect.R
+# N:M forward links: the per-element "Linked to..." field must render as a
+# multi-select so one element can declare many forward edges in a single panel
+# — removing the need to duplicate a node to express multiple edges.
+source_for_test("functions/isa_form_builders.R")
+
+test_that("every forward Linked field def is marked multiple = TRUE", {
+  i18n <- make_test_i18n()
+  ch <- c("", "X001: A", "X002: B")
+  linked_of <- function(fields, id) Filter(function(f) f$id == id, fields)[[1]]
+
+  expect_true(isTRUE(linked_of(isa_fields_es(i18n, ch),  "linkedgb")$multiple))
+  expect_true(isTRUE(linked_of(isa_fields_mpf(i18n, ch), "linkedes")$multiple))
+  expect_true(isTRUE(linked_of(isa_fields_p(i18n, ch),   "linkedmpf")$multiple))
+  expect_true(isTRUE(linked_of(isa_fields_a(i18n, ch),   "linkedp")$multiple))
+  expect_true(isTRUE(linked_of(isa_fields_d(i18n, ch),   "linkeda")$multiple))
+})
+
+test_that("a Pressures panel renders its Linked-to-MPF field as a <select multiple>", {
+  i18n <- make_test_i18n()
+  ns <- shiny::NS("isa")
+  fields <- isa_fields_p(i18n, c("", "MPF001: A", "MPF002: B"))
+  html <- as.character(build_entry_panel_ui(ns, "p", "P001", fields, i18n))
+
+  expect_match(html, "<select[^>]*multiple", perl = TRUE)      # is a multi-select
+  expect_match(html, 'value="MPF001: A"', fixed = TRUE)        # real choice present
+  expect_false(grepl('<option value=""', html, fixed = TRUE))  # blank placeholder dropped
+})
+
+test_that("a panel with no multiple field renders only single-selects (unchanged)", {
+  i18n <- make_test_i18n()
+  ns <- shiny::NS("isa")
+  fields <- isa_fields_gb(i18n)   # Goods & Benefits has no forward Linked field
+  html <- as.character(build_entry_panel_ui(ns, "gb", "GB001", fields, i18n))
+  expect_false(grepl("<select[^>]*multiple", html, perl = TRUE))
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-matrix-from-linked.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-matrix-from-linked.R
@@ -91,3 +91,37 @@ test_that("reconcile_loaded_element_ids generates ids when no id column exists",
   expect_equal(sum(nzchar(as.character(res$df$ID))), 3L)       # all rows got an id
   expect_equal(anyDuplicated(res$df$ID), 0)
 })
+
+# --- N:M multi-select forward links: one element -> many forward edges ---
+# A multi-select Linked widget hands `input[[...]]` a CHARACTER VECTOR of
+# label-form values. linked_select_to_ids must keep ALL of them (bare-id,
+# '|'-joined) so a single element row carries many edges — removing the need
+# to duplicate the node to express multiple forward links.
+test_that("linked_select_to_ids keeps every value from a multi-select vector", {
+  expect_equal(linked_select_to_ids(c("ES001: Fish", "ES002: Energy")),
+               "ES001|ES002")
+  expect_equal(linked_select_to_ids(c("GB001", "GB002", "GB003")),
+               "GB001|GB002|GB003")
+  # de-dupes repeated picks; drops blanks
+  expect_equal(linked_select_to_ids(c("P001: Overfishing", "", "P001: Overfishing")),
+               "P001")
+})
+
+test_that("linked_select_to_ids still handles legacy single + pipe-joined scalars", {
+  expect_equal(linked_select_to_ids("ES001: Fish"), "ES001")   # single label
+  expect_equal(linked_select_to_ids("GB001|GB002"), "GB001|GB002")  # stored value
+  expect_equal(linked_select_to_ids(NULL), "")
+  expect_equal(linked_select_to_ids(character(0)), "")
+})
+
+test_that("one element with N multi-selected links yields N edges in one matrix row", {
+  # Simulate the save path: a multi-select gives a vector; serialize -> store
+  # in LinkedMPF -> rebuild matrix. The single P001 row must produce 3 edges.
+  linked <- linked_select_to_ids(c("MPF001: A", "MPF002: B", "MPF003: C"))
+  el <- data.frame(ID = "P001", LinkedMPF = linked, Confidence = "Medium",
+                   stringsAsFactors = FALSE)
+  res <- rebuild_matrix_from_linked(el, "LinkedMPF",
+           source_ids = "P001", target_ids = c("MPF001", "MPF002", "MPF003"))
+  expect_equal(sum(nzchar(res$matrix["P001", ])), 3L)
+  expect_equal(nrow(res$matrix), 1L)  # still ONE node, not three duplicates
+})


### PR DESCRIPTION
## What

Each Standard-Entry element panel can now declare **many** forward links in one selection, so users no longer create duplicate-named nodes just to express multiple edges.

## Why

Investigation of the old `ISA_Export_20260525.xlsx` duplication found the literal same-ID dup was a **dead-fork (v1.13.x)** bug (positional counter IDs, no survivor tracker) — already fixed in canonical via stable IDs + reconcile (PR #25). The remaining gap was that the forward `Linked` field was **single-select**, pushing users toward duplicate-named nodes. The matrix backend (`rebuild_matrix_from_linked`) already supported N:M.

## Changes

- `build_field`: render `Linked` fields as multi-select (`multiple = TRUE`), dropping the blank placeholder; all 5 forward-link defs (linkedgb/es/mpf/p/a) marked.
- `linked_select_to_ids`: flatten a multi-select vector (still accepts legacy single / `|`-joined scalar), de-duping IDs.

## Tests

New: `test-isa-form-builders-multiselect.R` (render `<select multiple>`, defs marked), `test-matrix-from-linked.R` (+3: vector handling, one element → N edges in one row). Green: matrix-from-linked 29, modules 96 — 0 regressions. Verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-select linked fields: Users can now select multiple linked targets when defining ecosystem element relationships. Previously, each linked field accepted only one target; this enhancement enables selecting multiple related elements simultaneously.

* **Tests**
  * Comprehensive test suite added for multi-select form functionality, including validation of field rendering, selection handling, and proper deduplication of multiple selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/razinkele/SESTool/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->