### PR TITLE
fix(feedback): writable-fallback save + diagnosable errors + public list

### DIFF
--- a/MarineSABRES_SES_Shiny/app.R
+++ b/MarineSABRES_SES_Shiny/app.R
@@ -518,10 +518,11 @@ ui <- bs4DashPage(
       # ==================== GUIDEBOOK ====================
       bs4TabItem(tabName = "guidebook", guidebook_ui("guidebook", i18n)),
 
-      # ==================== FEEDBACK ADMIN (ADMIN_MODE only) ====================
+      # ============ FEEDBACK (list visible to all; admin tools gated) ==========
       bs4TabItem(tabName = "feedback_admin",
-                 if (exists("ADMIN_MODE") && ADMIN_MODE && exists("feedback_admin_ui", mode = "function"))
-                   feedback_admin_ui("feedback_admin", i18n = i18n)
+                 if (exists("feedback_admin_ui", mode = "function"))
+                   feedback_admin_ui("feedback_admin", i18n = i18n,
+                                     admin = (exists("ADMIN_MODE") && ADMIN_MODE))
                  else
                    tags$div()
       )
@@ -1074,10 +1075,10 @@ server <- function(input, output, session) {
   # Guidebook module
   guidebook_server("guidebook", project_data_reactive = project_data, i18n = session_i18n)
 
-  # Feedback admin module (ADMIN_MODE only)
-  if (exists("ADMIN_MODE") && ADMIN_MODE) {
-    feedback_admin_server("feedback_admin", i18n = session_i18n)
-  }
+  # Feedback module — list visible to all users; admin-only tools (resolve,
+  # duplicate detection, system-context detail) gated by the `admin` flag.
+  feedback_admin_server("feedback_admin", i18n = session_i18n,
+                        admin = (exists("ADMIN_MODE") && ADMIN_MODE))
 
   # ========== REACTIVE DATA PIPELINE ==========
   # Automatic propagation: ISA changes -> CLD regeneration -> Analysis invalidation

--- a/MarineSABRES_SES_Shiny/functions/feedback_analyzer.R
+++ b/MarineSABRES_SES_Shiny/functions/feedback_analyzer.R
@@ -126,6 +126,33 @@ load_feedback_log <- function(path = "data/user_feedback_log.ndjson") {
 }
 
 
+#' Load and merge several NDJSON feedback logs into one data frame
+#'
+#' Used so feedback written to a writable FALLBACK path (when the primary
+#' `data/` log is read-only — see save_feedback_local) still shows in the
+#' dashboard. Loads each path via `load_feedback_log`, row-binds, then dedupes
+#' across files by title+timestamp (keeping the last occurrence, matching the
+#' single-file dedup). Missing paths are skipped; all-missing yields the
+#' standard empty frame.
+#'
+#' @param paths character vector of NDJSON log paths.
+#' @return a data.frame with the same columns as `load_feedback_log`.
+load_feedback_logs <- function(paths) {
+  paths <- unique(paths[!is.na(paths) & nzchar(paths)])
+  if (length(paths) == 0L) return(load_feedback_log(""))   # standard empty frame
+
+  dfs <- lapply(paths, load_feedback_log)
+  non_empty <- Filter(function(d) is.data.frame(d) && nrow(d) > 0L, dfs)
+  if (length(non_empty) == 0L) return(load_feedback_log(""))
+
+  combined <- do.call(rbind, non_empty)
+  key <- paste(combined$title, combined$timestamp, sep = "\x01")
+  combined <- combined[!duplicated(key, fromLast = TRUE), , drop = FALSE]
+  rownames(combined) <- NULL
+  combined
+}
+
+
 # ============================================================================
 # compute_text_similarity
 # ============================================================================

--- a/MarineSABRES_SES_Shiny/functions/feedback_reporter.R
+++ b/MarineSABRES_SES_Shiny/functions/feedback_reporter.R
@@ -112,29 +112,51 @@ collect_system_context <- function(session     = NULL,
 
 #' Append one feedback payload as an NDJSON line to the local log
 #'
-#' @param payload  Named list to serialise as JSON
-#' @param path     Path to the NDJSON log file
-#' @return TRUE on success, FALSE on error
+#' Tries `path` first; if that directory/file isn't writable (the laguna
+#' read-only `data/` case), it falls back to a guaranteed-writable per-user
+#' location so a submission is NEVER silently lost. The real failure reason is
+#' carried back so callers can surface it instead of a generic error.
+#'
+#' @param payload        Named list to serialise as JSON
+#' @param path           Preferred NDJSON log path
+#' @param fallback_path  Writable path used only if `path` fails. Defaults to a
+#'   per-user data dir (tools::R_user_dir), which is writable on shiny-server.
+#' @return list(success, path, fellback, reason): `success` TRUE if written
+#'   anywhere; `path` where it landed (NA if lost); `fellback` TRUE if the
+#'   fallback was used; `reason` the primary failure message (NA on clean write).
 save_feedback_local <- function(payload,
                                  path = file.path(
                                    if (exists("PROJECT_ROOT")) PROJECT_ROOT else ".",
-                                   "data", "user_feedback_log.ndjson")) {
-  tryCatch({
-    dir_path <- dirname(path)
-    if (!dir.exists(dir_path)) dir.create(dir_path, recursive = TRUE)
+                                   "data", "user_feedback_log.ndjson"),
+                                 fallback_path = file.path(
+                                   tools::R_user_dir("MarineSABRES", "data"),
+                                   "user_feedback_log.ndjson")) {
+  .try_write <- function(p) {
+    tryCatch({
+      dir_path <- dirname(p)
+      if (!dir.exists(dir_path)) dir.create(dir_path, recursive = TRUE)
+      cat(jsonlite::toJSON(payload, auto_unbox = TRUE), "\n",
+          file = p, append = TRUE, sep = "")
+      TRUE
+    }, error = function(e) conditionMessage(e))   # character reason on failure
+  }
 
-    cat(
-      jsonlite::toJSON(payload, auto_unbox = TRUE),
-      "\n",
-      file   = path,
-      append = TRUE,
-      sep    = ""
-    )
-    TRUE
-  }, error = function(e) {
-    debug_log(paste("save_feedback_local failed:", e$message), "ERROR")
-    FALSE
-  })
+  primary <- .try_write(path)
+  if (isTRUE(primary)) {
+    return(list(success = TRUE, path = path, fellback = FALSE, reason = NA_character_))
+  }
+  debug_log(paste("save_feedback_local primary path failed:", primary), "WARN")
+
+  # Primary failed — try the writable fallback so feedback isn't lost.
+  if (!is.null(fallback_path) && !identical(fallback_path, path)) {
+    fb <- .try_write(fallback_path)
+    if (isTRUE(fb)) {
+      debug_log(paste("save_feedback_local wrote to fallback:", fallback_path), "WARN")
+      return(list(success = TRUE, path = fallback_path, fellback = TRUE, reason = primary))
+    }
+    debug_log(paste("save_feedback_local fallback path failed:", fb), "ERROR")
+  }
+  list(success = FALSE, path = NA_character_, fellback = FALSE, reason = primary)
 }
 
 
@@ -262,7 +284,11 @@ submit_feedback <- function(title,
   )
 
   # --- save locally first ---------------------------------------------------
-  local_success <- save_feedback_local(local_payload, path = log_path)
+  local_res      <- save_feedback_local(local_payload, path = log_path)
+  local_success  <- isTRUE(local_res$success)
+  local_path     <- local_res$path
+  local_fellback <- isTRUE(local_res$fellback)
+  local_error    <- local_res$reason
 
   # --- attempt GitHub -------------------------------------------------------
   gh_result     <- create_github_issue(title, issue_body, labels)
@@ -273,13 +299,17 @@ submit_feedback <- function(title,
   if (github_success && local_success) {
     update_payload        <- local_payload
     update_payload$github_url <- github_url
-    # Append a corrected entry; the original entry remains (acceptable for NDJSON)
-    save_feedback_local(update_payload, path = log_path)
+    # Append a corrected entry to wherever the first one landed (may be the
+    # fallback path); the original entry remains (acceptable for NDJSON).
+    save_feedback_local(update_payload, path = local_path)
   }
 
   list(
     local_success  = local_success,
     github_success = github_success,
-    github_url     = github_url
+    github_url     = github_url,
+    local_path     = local_path,
+    local_fellback = local_fellback,
+    local_error    = local_error
   )
 }

--- a/MarineSABRES_SES_Shiny/functions/ui_sidebar.R
+++ b/MarineSABRES_SES_Shiny/functions/ui_sidebar.R
@@ -456,19 +456,20 @@ generate_sidebar_menu <- function(user_level = "intermediate", i18n) {
     )
   ))
 
-  # Admin panel (only when ADMIN_MODE is enabled)
-  if (exists("ADMIN_MODE") && ADMIN_MODE) {
-    menu_items <- c(menu_items, list(
-      add_menu_tooltip(
-        bs4SidebarMenuItem(
-          safe_t("modules.feedback_admin.menu_label", i18n_obj = i18n),
-          tabName = "feedback_admin",
-          icon = icon("lock")
-        ),
-        safe_t("modules.feedback_admin.dashboard_tab", i18n_obj = i18n)
-      )
-    ))
-  }
+  # Feedback list (all users). Admins get the lock icon + "Admin" label and the
+  # extra admin tools inside; everyone else sees a read-only "Feedback" list.
+  .fb_admin <- exists("ADMIN_MODE") && ADMIN_MODE
+  menu_items <- c(menu_items, list(
+    add_menu_tooltip(
+      bs4SidebarMenuItem(
+        if (.fb_admin) safe_t("modules.feedback_admin.menu_label", i18n_obj = i18n)
+        else           safe_t("ui.modals.feedback.button_label", i18n_obj = i18n),
+        tabName = "feedback_admin",
+        icon = icon(if (.fb_admin) "lock" else "comment-dots")
+      ),
+      safe_t("modules.feedback_admin.dashboard_tab", i18n_obj = i18n)
+    )
+  ))
 
   # Add horizontal rule and Quick Actions (all levels)
   menu_items <- c(menu_items, list(

--- a/MarineSABRES_SES_Shiny/modules/feedback_admin_module.R
+++ b/MarineSABRES_SES_Shiny/modules/feedback_admin_module.R
@@ -2,7 +2,7 @@
 # Admin module: feedback log dashboard and duplicate detection
 # Only loaded/rendered when ADMIN_MODE is TRUE (set in global.R)
 
-feedback_admin_ui <- function(id, i18n) {
+feedback_admin_ui <- function(id, i18n, admin = TRUE) {
   tryCatch(shiny.i18n::usei18n(i18n$translator %||% i18n), error = function(e) NULL)
   ns <- NS(id)
 
@@ -17,13 +17,14 @@ feedback_admin_ui <- function(id, i18n) {
       )
     ),
 
-    bs4TabCard(
+    do.call(bs4TabCard, c(list(
       id = ns("admin_tabs"),
       width = 12,
       side = "left",
       status = "primary",
       solidHeader = FALSE,
-      collapsible = FALSE,
+      collapsible = FALSE
+    ), Filter(Negate(is.null), list(
 
       # ================================================================
       # Tab 1 – Feedback Dashboard
@@ -89,9 +90,9 @@ feedback_admin_ui <- function(id, i18n) {
       ),
 
       # ================================================================
-      # Tab 2 – Duplicate Detection
+      # Tab 2 – Duplicate Detection (admin only)
       # ================================================================
-      tabPanel(
+      if (isTRUE(admin)) tabPanel(
         title = tagList(
           tags$i(class = "fas fa-copy", style = "margin-right: 5px;"),
           i18n$t("modules.feedback_admin.duplicates_tab")
@@ -140,12 +141,12 @@ feedback_admin_ui <- function(id, i18n) {
           )
         )
       )
-    )
+    ))))
   )
 }
 
 
-feedback_admin_server <- function(id, i18n, event_bus = NULL) {
+feedback_admin_server <- function(id, i18n, event_bus = NULL, admin = TRUE) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -161,6 +162,13 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
     # Inert in production (option is unset).
     log_path <- getOption("marinesabres.feedback_log_path", log_path)
 
+    # Writable fallback used by save_feedback_local() when the primary data/
+    # log is read-only (the laguna case). Merge it on read so those entries
+    # still appear in the dashboard. Same default as save_feedback_local().
+    fallback_log_path <- file.path(
+      tools::R_user_dir("MarineSABRES", "data"), "user_feedback_log.ndjson")
+    load_feedback <- function() load_feedback_logs(c(log_path, fallback_log_path))
+
     # ------------------------------------------------------------------
     # Reactive: feedback data (loaded once on session start, refreshable)
     # ------------------------------------------------------------------
@@ -174,7 +182,7 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
     # Load data once on session start
     observe({
       df <- tryCatch(
-        load_feedback_log(log_path),
+        load_feedback(),
         error = function(e) {
           debug_log(paste("feedback_admin: load error:", e$message), "ERROR")
           data.frame(
@@ -321,6 +329,44 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
       }
 
       # Build display data.frame — validate URL starts with https:// to prevent XSS
+      status_style <- function(dt) DT::formatStyle(dt, "Status",
+        backgroundColor = DT::styleEqual(
+          c("open", "addressed", "wont_fix", "duplicate"),
+          c("#e9ecef", "#d4edda", "#e2e3e5", "#fff3cd")))
+
+      # Columns shown to everyone: date / type / title / status. No system
+      # context, description, github link, or actions for non-admins (privacy).
+      base_disp <- data.frame(
+        Date   = format(suppressWarnings(
+          as.POSIXct(df$timestamp, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC")),
+          "%Y-%m-%d", tz = "UTC"),
+        Type   = df$type,
+        Title  = df$title,
+        Status = df$status,
+        stringsAsFactors = FALSE
+      )
+
+      if (!isTRUE(admin)) {
+        return(
+          DT::datatable(
+            base_disp,
+            colnames  = c(
+              i18n$t("modules.feedback_admin.col_date"),
+              i18n$t("modules.feedback_admin.col_type"),
+              i18n$t("modules.feedback_admin.col_title"),
+              i18n$t("modules.feedback_admin.status")
+            ),
+            escape    = TRUE,
+            selection = "none",
+            rownames  = FALSE,
+            options   = list(pageLength = 15, order = list(list(0, "desc")),
+                             dom = "lfrtip", scrollX = TRUE)
+          ) |> status_style()
+        )
+      }
+
+      # --- admin only: full columns, github link, per-row mark-addressed ----
+      # Validate URL starts with https:// to prevent XSS.
       is_valid_url <- !is.na(df$github_url) & nzchar(df$github_url) &
                       df$github_url != "NA" & grepl("^https://", df$github_url)
       github_html <- ifelse(is_valid_url,
@@ -345,17 +391,15 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
       }, character(1L))
 
       disp <- data.frame(
-        Date        = format(suppressWarnings(
-          as.POSIXct(df$timestamp, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC")),
-          "%Y-%m-%d", tz = "UTC"),
-        Type        = df$type,
-        Title       = df$title,
+        Date        = base_disp$Date,
+        Type        = base_disp$Type,
+        Title       = base_disp$Title,
         Description = ifelse(
           nchar(df$description) > 100,
           paste0(substr(df$description, 1, 100), "\u2026"),
           df$description
         ),
-        Status      = df$status,
+        Status      = base_disp$Status,
         GitHub      = github_html,
         Action      = action_html,
         stringsAsFactors = FALSE
@@ -381,15 +425,14 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
           dom        = "lfrtip",
           scrollX    = TRUE
         )
-      ) |> DT::formatStyle("Status", backgroundColor = DT::styleEqual(
-            c("open", "addressed", "wont_fix", "duplicate"),
-            c("#e9ecef", "#d4edda", "#e2e3e5", "#fff3cd")))
+      ) |> status_style()
     })
 
     # ------------------------------------------------------------------
     # Row click -> open detail modal
     # ------------------------------------------------------------------
     observeEvent(input$feedback_table_rows_selected, {
+      req(isTRUE(admin))   # detail modal shows system context — admin only
       idx <- input$feedback_table_rows_selected
       req(length(idx) > 0)
 
@@ -455,7 +498,7 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
     observeEvent(input$recalculate, {
       # Reload data first
       df <- tryCatch(
-        load_feedback_log(log_path),
+        load_feedback(),
         error = function(e) {
           debug_log(paste("feedback_admin recalculate: load error:", e$message), "ERROR")
           rv$feedback_df
@@ -581,7 +624,7 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
           type = "message"
         )
         # Reload and re-detect
-        df <- tryCatch(load_feedback_log(log_path), error = function(e) rv$feedback_df)
+        df <- tryCatch(load_feedback(), error = function(e) rv$feedback_df)
         rv$feedback_df <- df
         run_detection(run_detection() + 1L)
       } else {
@@ -597,6 +640,7 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
     # Mirrors mark_dup: carries explicit line_num (filter-safe).
     # ------------------------------------------------------------------
     observeEvent(input$mark_addr_click, {
+      req(isTRUE(admin))   # resolving feedback is an admin action
       req(!is.null(input$mark_addr_click$line))
       rv$pending_mark_line <- as.integer(input$mark_addr_click$line)
       showModal(modalDialog(
@@ -635,7 +679,7 @@ feedback_admin_server <- function(id, i18n, event_bus = NULL) {
       )
       removeModal()
       if (isTRUE(ok)) {
-        rv$feedback_df <- load_feedback_log(log_path)
+        rv$feedback_df <- load_feedback()
         showNotification(
           i18n$t("modules.feedback_admin.marked_addressed"),
           type = "message"

--- a/MarineSABRES_SES_Shiny/server/modals.R
+++ b/MarineSABRES_SES_Shiny/server/modals.R
@@ -1785,7 +1785,14 @@ setup_feedback_modal_handlers <- function(input, output, session, i18n,
 
     # Show result — 3-way check: both failed, github success, or local-only success
     if (!result$local_success && !result$github_success) {
-      showNotification(i18n$t("ui.modals.feedback.error_save_failed"), type = "error", duration = 8)
+      # Surface the REAL reason (e.g. "Permission denied" on a read-only data/)
+      # so the failure is diagnosable instead of a generic message. The reason
+      # is an R error detail — keep the i18n prefix, append the raw cause.
+      msg <- i18n$t("ui.modals.feedback.error_save_failed")
+      if (!is.null(result$local_error) && !is.na(result$local_error) && nzchar(result$local_error)) {
+        msg <- paste0(msg, " (", result$local_error, ")")
+      }
+      showNotification(msg, type = "error", duration = 12)
     } else if (result$github_success) {
       showNotification(
         tagList(

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-analyzer.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-analyzer.R
@@ -571,3 +571,40 @@ test_that("all feedback_admin i18n keys exist for all 9 languages", {
     }
   }
 })
+
+# ---------------------------------------------------------------------------
+# load_feedback_logs: merge primary + fallback logs (so feedback written to a
+# writable fallback path when data/ is read-only still appears in the dashboard)
+# ---------------------------------------------------------------------------
+test_that("load_feedback_logs merges entries from multiple log files", {
+  skip_if_not(exists("load_feedback_logs", mode = "function"),
+              "load_feedback_logs not available")
+
+  p1 <- tempfile(fileext = ".ndjson"); p2 <- tempfile(fileext = ".ndjson")
+  on.exit(unlink(c(p1, p2)), add = TRUE)
+  writeLines('{"title":"A","type":"bug","timestamp":"2026-01-01T00:00:00Z"}', p1)
+  writeLines('{"title":"B","type":"suggestion","timestamp":"2026-01-02T00:00:00Z"}', p2)
+
+  df <- load_feedback_logs(c(p1, p2))
+  expect_equal(nrow(df), 2L)
+  expect_setequal(df$title, c("A", "B"))
+})
+
+test_that("load_feedback_logs dedupes the same entry across files and tolerates missing paths", {
+  skip_if_not(exists("load_feedback_logs", mode = "function"),
+              "load_feedback_logs not available")
+
+  p1 <- tempfile(fileext = ".ndjson"); p2 <- tempfile(fileext = ".ndjson")
+  on.exit(unlink(c(p1, p2)), add = TRUE)
+  same <- '{"title":"Dup","type":"bug","timestamp":"2026-01-01T00:00:00Z"}'
+  writeLines(same, p1); writeLines(same, p2)
+
+  df <- load_feedback_logs(c(p1, p2, file.path(tempdir(), "does-not-exist.ndjson")))
+  expect_equal(nrow(df), 1L)              # cross-file duplicate collapsed
+  expect_equal(df$title, "Dup")
+
+  # all-missing -> empty df with the standard columns (no error)
+  empty <- load_feedback_logs(file.path(tempdir(), "nope.ndjson"))
+  expect_equal(nrow(empty), 0L)
+  expect_true(all(c("line_num", "title", "type", "status", "timestamp") %in% names(empty)))
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-reporter.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-feedback-reporter.R
@@ -95,7 +95,9 @@ test_that("save_feedback_local writes valid NDJSON and returns TRUE", {
   payload <- list(title = "Test entry", type = "bug", count = 1L)
   result  <- save_feedback_local(payload, path = tmp_file)
 
-  expect_true(result)
+  expect_true(result$success)
+  expect_false(result$fellback)
+  expect_equal(result$path, tmp_file)
   expect_true(file.exists(tmp_file))
 
   lines <- readLines(tmp_file, warn = FALSE)
@@ -137,21 +139,48 @@ test_that("save_feedback_local appends without corrupting existing entries", {
 })
 
 # ---------------------------------------------------------------------------
-# Test 4: save_feedback_local returns FALSE on write error
+# Test 4a: falls back to a writable path when the primary is unwritable
+# (so feedback is NEVER silently lost — the laguna read-only data/ case)
 # ---------------------------------------------------------------------------
-test_that("save_feedback_local returns FALSE on write error", {
+test_that("save_feedback_local falls back to a writable path when primary fails", {
   skip_if_not(exists("save_feedback_local", mode = "function"),
               "save_feedback_local not available")
 
-  # Create a real file, then use it AS a directory component so the path is
-  # guaranteed to fail on every OS (file-as-dir is always an error).
-  tmp_file <- tempfile(fileext = ".txt")
-  writeLines("block", tmp_file)
-  on.exit(unlink(tmp_file), add = TRUE)
+  # A real file used AS a directory component → primary write fails on every OS.
+  blocker <- tempfile(fileext = ".txt"); writeLines("block", blocker)
+  on.exit(unlink(blocker), add = TRUE)
+  bad_primary <- file.path(blocker, "subdir", "feedback.ndjson")
 
-  bad_path <- file.path(tmp_file, "subdir", "feedback.ndjson")
-  result   <- save_feedback_local(list(x = 1), path = bad_path)
-  expect_false(result)
+  fallback <- tempfile(fileext = ".ndjson")
+  on.exit(unlink(fallback), add = TRUE)
+
+  result <- save_feedback_local(list(title = "kept"), path = bad_primary,
+                                fallback_path = fallback)
+
+  expect_true(result$success)                 # saved, not lost
+  expect_true(result$fellback)                # via the fallback
+  expect_equal(result$path, fallback)         # reports where it landed
+  expect_true(!is.null(result$reason) && nzchar(result$reason)) # carries the primary failure reason
+  expect_true(file.exists(fallback))
+  expect_equal(jsonlite::fromJSON(readLines(fallback, warn = FALSE)[1])$title, "kept")
+})
+
+# ---------------------------------------------------------------------------
+# Test 4b: success = FALSE only when BOTH primary and fallback fail
+# ---------------------------------------------------------------------------
+test_that("save_feedback_local reports failure when primary AND fallback fail", {
+  skip_if_not(exists("save_feedback_local", mode = "function"),
+              "save_feedback_local not available")
+
+  blocker <- tempfile(fileext = ".txt"); writeLines("block", blocker)
+  on.exit(unlink(blocker), add = TRUE)
+  bad_primary  <- file.path(blocker, "a", "feedback.ndjson")
+  bad_fallback <- file.path(blocker, "b", "feedback.ndjson")
+
+  result <- save_feedback_local(list(x = 1), path = bad_primary,
+                                fallback_path = bad_fallback)
+  expect_false(result$success)
+  expect_true(!is.null(result$reason) && nzchar(result$reason))   # surfaces WHY it failed
 })
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Submitting feedback fails on laguna: `save_feedback_local()` returns FALSE because `data/user_feedback_log.ndjson` (or `data/`) isn't writable by the shiny-server user (recurs after deploys; the ndjson is gitignored so ownership drifts). The submit code itself is correct — verified working locally end-to-end.

> **Ops note:** the canonical fix on laguna is `chmod g+w data data/user_feedback_log.ndjson`. With this PR, submits succeed via the fallback even without it.

## Submit hardening

- `save_feedback_local()` returns `list(success, path, fellback, reason)` and **falls back to a writable per-user path** (`tools::R_user_dir`) when the primary is unwritable — feedback never silently lost. `submit_feedback()` propagates path/reason/fellback.
- The modal surfaces the **real failure reason** instead of a generic message.
- New `load_feedback_logs()` merges primary + fallback (dedupe by title+timestamp); the dashboard reads both so fallback entries still appear.

## Reformat — feedback list visible to ALL users

- New "Feedback" sidebar item for everyone; tab + server un-gated behind an `admin` flag (= `ADMIN_MODE`) instead of hidden.
- Non-admin table shows only **date / type / title / status** (no system context, description, github, actions). Duplicate-detection tab, row-click context detail, and Mark-addressed stay admin-only.

## Tests

New: `save_feedback_local` fallback/reason; `load_feedback_logs` merge/dedupe. Green: feedback-reporter 232, analyzer 374, admin-module 21, modules 96 — 0 regressions. Verified live (non-admin sidebar → dashboard → submit → 4-column table → no dup tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)