### PR TITLE
fix(download): chart PNG downloads were served as HTML (feedback #7)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/export_functions.R
+++ b/MarineSABRES_SES_Shiny/functions/export_functions.R
@@ -19,8 +19,27 @@ generate_export_filename <- function(prefix, extension) {
 # VISUALIZATION EXPORT FUNCTIONS
 # ============================================================================
 
+#' Save a ggplot as PNG to a (possibly extension-less) path
+#'
+#' Shiny's downloadHandler hands `content = function(file)` an EXTENSION-LESS
+#' temp path. ggsave() infers its device from the filename extension, so on
+#' such a path it errors ("supply `filename` with a file extension or supply
+#' `device`") and Shiny then serves an HTML error page — the file downloads as
+#' HTML (feedback #7 "Can't download tables"). Forcing `device = "png"` makes
+#' the save work regardless of the path's extension.
+#'
+#' @param plot ggplot object
+#' @param file Output path (extension optional)
+#' @param width,height,dpi ggsave dimensions
+#' @return `file`, invisibly (side effect: writes a PNG)
+save_ggplot_png <- function(plot, file, width = 10, height = 6, dpi = 150) {
+  ggplot2::ggsave(file, plot = plot, device = "png",
+                  width = width, height = height, dpi = dpi, bg = "white")
+  invisible(file)
+}
+
 #' Export CLD as HTML
-#' 
+#'
 #' @param visnet visNetwork object
 #' @param file_path Output file path
 #' @return NULL (side effect: saves file)

--- a/MarineSABRES_SES_Shiny/modules/analysis_leverage.R
+++ b/MarineSABRES_SES_Shiny/modules/analysis_leverage.R
@@ -555,7 +555,10 @@ analysis_leverage_server <- function(id, project_data_reactive, i18n, event_bus 
             panel.grid.major.y = element_blank()
           )
 
-        ggsave(file, plot = p, width = 10, height = max(6, nrow(df) * 0.4), dpi = 150, bg = "white")
+        # device = "png" forced via helper: Shiny hands us an extension-less
+        # temp path, which ggsave can't infer a device from (feedback #7 —
+        # chart downloaded as HTML error page).
+        save_ggplot_png(p, file, width = 10, height = max(6, nrow(df) * 0.4), dpi = 150)
       }
     )
 

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-ggplot-png-download.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-ggplot-png-download.R
@@ -1,0 +1,23 @@
+# tests/testthat/test-ggplot-png-download.R
+# Regression for feedback #7 "Can't download tables" — chart downloads arrived as
+# HTML. Cause: Shiny's downloadHandler passes content=function(file) an
+# EXTENSION-LESS temp path, and ggsave() can't infer the device from it, so it
+# errors and Shiny serves an HTML error page. save_ggplot_png() must force
+# device = "png" so an extension-less path still produces a real PNG.
+source_for_test("functions/export_functions.R")
+
+test_that("save_ggplot_png writes a real PNG to an EXTENSION-LESS path (Shiny download condition)", {
+  skip_if_not_installed("ggplot2")
+  p <- ggplot2::ggplot(data.frame(x = 1:3, y = 1:3), ggplot2::aes(x, y)) +
+    ggplot2::geom_col()
+
+  f <- tempfile()                 # no extension — exactly what downloadHandler passes
+  on.exit(unlink(f), add = TRUE)
+
+  expect_error(save_ggplot_png(p, f, width = 10, height = 6, dpi = 150), NA)  # must NOT error
+  expect_true(file.exists(f) && file.size(f) > 0)
+
+  # PNG magic bytes: 89 50 4E 47 ("\x89PNG")
+  sig <- readBin(f, what = "raw", n = 4)
+  expect_equal(sig, as.raw(c(0x89, 0x50, 0x4E, 0x47)))
+})


### PR DESCRIPTION
## Problem (feedback #7 "Can't download tables")

> *Even though it's written that tables are gonna be in excel or png, they are being downloaded as html, and then it's not possible to download.*

The leverage **chart (PNG)** download arrived as an HTML file. Shiny's `downloadHandler` passes `content = function(file)` an **extension-less** temp path; `ggsave()` infers its device from the filename extension, so on that path it throws (`supply filename with a file extension or supply device`) and Shiny serves an **HTML error page** instead of the PNG.

Confirmed on laguna: `ggsave(tempfile(), ...)` → FAIL; `png(tempfile(), ...)` and `openxlsx::saveWorkbook(tempfile())` → OK. So only the `ggsave` path was affected (the Excel download already works; `png()`-based metrics/loops downloads were fine).

## Fix
- New `save_ggplot_png()` helper forces `device = "png"` so an extension-less path still yields a real PNG.
- `analysis_leverage.R` chart download uses it.

## Test
`test-ggplot-png-download.R`: asserts `save_ggplot_png()` writes valid PNG magic bytes (`89 50 4E 47`) to an **extension-less** path (the exact Shiny download condition). Green: ggplot-png 3, export-functions 16, enhanced 70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PNG export functionality for analysis plots with improved compatibility for download handlers and extension-less file paths.

* **Bug Fixes**
  * Fixed leverage analysis plot downloads to properly save as PNG files.

* **Tests**
  * Added regression test for PNG export download functionality to verify correct file format and output integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->