### PR TITLE
fix(export): implement Export Data + Visualization downloads (feedback #8)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/export_functions.R
+++ b/MarineSABRES_SES_Shiny/functions/export_functions.R
@@ -38,6 +38,57 @@ save_ggplot_png <- function(plot, file, width = 10, height = 6, dpi = 150) {
   invisible(file)
 }
 
+#' Write a project-data export list to a file in the chosen format
+#'
+#' Replaces the old Export-page placeholder that wrote a text file with a binary
+#' extension (feedback #8 "data export" — downloaded file could not be opened).
+#' Works on Shiny's extension-less downloadHandler temp path: every writer here
+#' is extension-agnostic (openxlsx / jsonlite / save / write.csv all take an
+#' explicit path).
+#'
+#' @param export_list named list of components (data frames and/or plain lists)
+#' @param format one of "Excel (.xlsx)", "CSV (.csv)", "JSON (.json)", "R Data (.RData)"
+#' @param file output path (extension optional)
+#' @return `file`, invisibly
+write_data_export <- function(export_list, format, file) {
+  if (identical(format, "Excel (.xlsx)")) {
+    wb <- openxlsx::createWorkbook()
+    for (name in names(export_list)) {
+      item <- export_list[[name]]
+      sheet <- substr(name, 1, 31)
+      if (is.data.frame(item) && nrow(item) > 0) {
+        openxlsx::addWorksheet(wb, sheet)
+        openxlsx::writeData(wb, sheet, item)
+      } else if (is.list(item) && !is.data.frame(item) && length(item) > 0) {
+        df <- tryCatch(as.data.frame(t(unlist(item)), stringsAsFactors = FALSE),
+                       error = function(e) NULL)
+        if (!is.null(df)) { openxlsx::addWorksheet(wb, sheet); openxlsx::writeData(wb, sheet, df) }
+      }
+    }
+    if (length(openxlsx::sheets(wb)) == 0) {        # never write an empty workbook
+      openxlsx::addWorksheet(wb, "Export")
+      openxlsx::writeData(wb, "Export", data.frame(message = "No data selected to export"))
+    }
+    openxlsx::saveWorkbook(wb, file, overwrite = TRUE)
+
+  } else if (identical(format, "CSV (.csv)")) {
+    # CSV is flat: write the first data-frame component (else a message row).
+    dfs <- Filter(function(x) is.data.frame(x) && nrow(x) > 0, export_list)
+    if (length(dfs) > 0) utils::write.csv(dfs[[1]], file, row.names = FALSE)
+    else utils::write.csv(data.frame(message = "No tabular data to export"), file, row.names = FALSE)
+
+  } else if (identical(format, "JSON (.json)")) {
+    writeLines(jsonlite::toJSON(export_list, pretty = TRUE, auto_unbox = TRUE), file)
+
+  } else if (identical(format, "R Data (.RData)")) {
+    save(export_list, file = file)
+
+  } else {
+    stop(sprintf("write_data_export: unsupported format '%s'", format))
+  }
+  invisible(file)
+}
+
 #' Export CLD as HTML
 #'
 #' @param visnet visNetwork object

--- a/MarineSABRES_SES_Shiny/modules/export_reports_module.R
+++ b/MarineSABRES_SES_Shiny/modules/export_reports_module.R
@@ -387,9 +387,50 @@ export_reports_server <- function(id, project_data_reactive, i18n, event_bus = N
         )
       },
       content = function(file) {
-        # Data export not yet implemented - write placeholder file
-        showNotification(i18n$t("common.messages.data_export_not_implemented"), type = "warning")
-        writeLines("Data export is not yet implemented. Please use the Report generation feature instead.", file)
+        tryCatch({
+          data <- project_data_reactive()
+          if (is.null(data)) {
+            showNotification(i18n$t("common.messages.no_data_to_export"), type = "error")
+            return(NULL)
+          }
+          components <- input$export_data_components
+          export_list <- list()
+          if ("metadata" %in% components) {
+            export_list$metadata <- data$data$metadata
+            export_list$project_info <- list(
+              project_id = data$project_id, project_name = data$project_name,
+              created_at = as.character(data$created_at),
+              last_modified = as.character(data$last_modified))
+          }
+          if ("pims" %in% components) export_list$pims <- data$data$pims
+          if ("isa_data" %in% components) {
+            isa <- data$data$isa_data
+            export_list$goods_benefits     <- isa$goods_benefits
+            export_list$ecosystem_services <- isa$ecosystem_services
+            export_list$marine_processes   <- isa$marine_processes
+            export_list$pressures          <- isa$pressures
+            export_list$activities         <- isa$activities
+            export_list$drivers            <- isa$drivers
+            export_list$bot_data           <- isa$bot_data
+          }
+          if ("cld" %in% components) {
+            export_list$cld_nodes <- data$data$cld$nodes
+            export_list$cld_edges <- data$data$cld$edges
+            export_list$cld_loops <- data$data$cld$loops
+          }
+          if ("analysis" %in% components)  export_list$analysis_results  <- data$data$analysis
+          if ("responses" %in% components) export_list$response_measures <- data$data$responses
+
+          # Drop NULL/empty components so we never emit an empty/garbage file.
+          export_list <- Filter(function(x) !is.null(x) && length(x) > 0, export_list)
+
+          write_data_export(export_list, input$export_data_format, file)
+          showNotification(i18n$t("common.messages.data_exported_successfully"), type = "message")
+        }, error = function(e) {
+          debug_log(paste("Data export error:", conditionMessage(e)), "EXPORT")
+          showNotification(paste(i18n$t("common.messages.export_failed"), conditionMessage(e)),
+                           type = "error", duration = 10)
+        })
       }
     )
 
@@ -405,12 +446,58 @@ export_reports_server <- function(id, project_data_reactive, i18n, event_bus = N
         )
       },
       content = function(file) {
-        # Visualization export not yet implemented - write placeholder file
-        showNotification(
-          "Visualization export not yet implemented",
-          type = "warning"
-        )
-        writeLines("Visualization export is not yet implemented.", file)
+        tryCatch({
+          data <- project_data_reactive()
+          nodes <- data$data$cld$nodes
+          if (is.null(nodes) || !is.data.frame(nodes) || nrow(nodes) == 0) {
+            showNotification(i18n$t("common.misc.no_cld_data_to_export_please_create_a_cld_first"), type = "error")
+            return(NULL)
+          }
+          edges <- data$data$cld$edges
+          if (is.null(edges) || !is.data.frame(edges) || nrow(edges) == 0) {
+            edges <- data.frame(from = character(0), to = character(0), stringsAsFactors = FALSE)
+          }
+          format <- input$export_viz_format
+          width  <- input$export_viz_width  %||% 1200
+          height <- input$export_viz_height %||% 900
+
+          if (format == "HTML (.html)") {
+            viz <- visNetwork(nodes, edges, width = paste0(width, "px"), height = paste0(height, "px")) %>%
+              visNodes(borderWidth = 2, font = list(size = 14)) %>%
+              visEdges(arrows = "to", smooth = list(enabled = TRUE, type = "curvedCW")) %>%
+              visOptions(highlightNearest = list(enabled = TRUE, hover = TRUE), nodesIdSelection = TRUE) %>%
+              visInteraction(navigationButtons = TRUE, hover = TRUE, zoomView = TRUE)
+            # saveWidget wants a real .html path; write to a temp then copy to the
+            # extension-less downloadHandler file.
+            tmp <- tempfile(fileext = ".html")
+            on.exit(unlink(tmp), add = TRUE)
+            visSave(viz, tmp)
+            file.copy(tmp, file, overwrite = TRUE)
+          } else {
+            # Static export via igraph (png/svg/pdf devices are extension-agnostic).
+            g <- graph_from_data_frame(d = edges, vertices = nodes, directed = TRUE)
+            ecol <- if ("link_type" %in% names(edges)) {
+              ifelse(edges$link_type == "positive", "#06D6A0", "#E63946")
+            } else if ("polarity" %in% names(edges)) {
+              ifelse(edges$polarity == "+", "#06D6A0", "#E63946")
+            } else "#999999"
+            if (format == "PNG (.png)")      png(file, width = width, height = height, res = 150)
+            else if (format == "SVG (.svg)") svg(file, width = width / 100, height = height / 100)
+            else                             pdf(file, width = width / 100, height = height / 100)
+            on.exit(tryCatch(grDevices::dev.off(), error = function(e2) NULL), add = TRUE)
+            op <- par(mar = if (exists("PLOT_MARGINS")) PLOT_MARGINS else c(1, 1, 2, 1))
+            plot(g, vertex.label.cex = 0.8, vertex.label.color = "black",
+                 vertex.frame.color = "gray", edge.color = ecol, edge.arrow.size = 0.5,
+                 edge.curved = 0.2, main = i18n$t("modules.export.cld_diagram_title"))
+            par(op)
+          }
+          showNotification(i18n$t("common.messages.visualization_exported_successfully"), type = "message")
+        }, error = function(e) {
+          tryCatch(grDevices::dev.off(), error = function(e2) NULL)
+          debug_log(paste("Visualization export error:", conditionMessage(e)), "EXPORT")
+          showNotification(paste(i18n$t("common.messages.export_failed"), conditionMessage(e)),
+                           type = "error", duration = 10)
+        })
       }
     )
 

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-data-export.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-data-export.R
@@ -1,0 +1,50 @@
+# tests/testthat/test-data-export.R
+# Regression for feedback #8 "data export": the Export-page Download Data button
+# was a placeholder that wrote a TEXT file with a .xlsx/.csv/.json/.RData name,
+# so the downloaded file could not be opened. write_data_export() must produce a
+# real, openable file for each format — including on the EXTENSION-LESS temp path
+# that Shiny's downloadHandler passes (the same trap that broke #7).
+source_for_test("functions/export_functions.R")
+
+make_list <- function() list(
+  goods_benefits = data.frame(ID = c("GB001", "GB002"), Name = c("Fish", "Energy"),
+                              stringsAsFactors = FALSE),
+  project_info = list(project_name = "Demo", project_id = "P1")
+)
+
+test_that("write_data_export writes a real, readable XLSX to an extension-less path", {
+  skip_if_not_installed("openxlsx")
+  f <- tempfile(); on.exit(unlink(f), add = TRUE)
+  expect_error(write_data_export(make_list(), "Excel (.xlsx)", f), NA)
+  expect_true(file.exists(f) && file.size(f) > 0)
+  # XLSX is a ZIP: first two bytes are "PK"
+  expect_equal(readBin(f, "raw", 2), as.raw(c(0x50, 0x4B)))
+  # openxlsx READ requires a .xlsx name (the WRITE to an extension-less path is
+  # what matters; Shiny serves it with the .xlsx filename). Copy to read back.
+  fx <- paste0(f, ".xlsx"); on.exit(unlink(fx), add = TRUE)
+  file.copy(f, fx, overwrite = TRUE)
+  sheets <- openxlsx::getSheetNames(fx)
+  expect_true("goods_benefits" %in% sheets)
+  df <- openxlsx::read.xlsx(fx, sheet = "goods_benefits")
+  expect_equal(nrow(df), 2L)
+})
+
+test_that("write_data_export writes valid JSON and reloadable RData", {
+  fj <- tempfile(); on.exit(unlink(fj), add = TRUE)
+  write_data_export(make_list(), "JSON (.json)", fj)
+  parsed <- jsonlite::fromJSON(fj)
+  expect_true("goods_benefits" %in% names(parsed))
+
+  fr <- tempfile(); on.exit(unlink(fr), add = TRUE)
+  write_data_export(make_list(), "R Data (.RData)", fr)
+  e <- new.env(); load(fr, envir = e)
+  expect_true("export_list" %in% ls(e))
+  expect_equal(e$export_list$project_info$project_name, "Demo")
+})
+
+test_that("write_data_export CSV produces a readable table", {
+  fc <- tempfile(); on.exit(unlink(fc), add = TRUE)
+  write_data_export(make_list(), "CSV (.csv)", fc)
+  df <- read.csv(fc, stringsAsFactors = FALSE)
+  expect_true(nrow(df) >= 1)
+})


### PR DESCRIPTION
## Problem (feedback #8 "data export")

> *A notice pops up, that data export has not yet been implemented. And when I try to download… I can't open up the file on my computer.*

The Export page's **Download Data** and **Download Visualization** were placeholders that wrote a **text** file with a `.xlsx`/`.png`/… name → the download couldn't be opened, plus a "not yet implemented" notice. A working implementation existed in `server/export_handlers.R` but was bound to **non-namespaced** outputs the module UI never used, so the **module placeholders** ran instead.

## Fix
- New `write_data_export()` helper — writes a real **Excel / CSV / JSON / RData** file; extension-agnostic, so Shiny's extension-less temp path works.
- `download_data` builds the export list from the selected components and writes a real file via the helper.
- `download_viz` — real **HTML** (visSave → temp `.html` → copy) and **PNG/SVG/PDF** (igraph plot via explicit devices); edge colour falls back `link_type → polarity → grey`.

## Test
`test-data-export.R`: valid XLSX (PK header + readable sheet), JSON, reloadable RData, CSV — all on an **extension-less** path (the same Shiny trap as #7). Green: data-export 9, export-functions 16, export-reports-module 10.

Note: the now-redundant non-namespaced handlers in `server/export_handlers.R` (unused dead code) are left untouched to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)