### PR TITLE
fix: Phase A quick wins from code review (H4, M1, M13, M7, L16)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/network_analysis.R
+++ b/MarineSABRES_SES_Shiny/functions/network_analysis.R
@@ -158,20 +158,46 @@ calculate_centrality <- function(graph) {
 
 #' Detect feedback loops (simple cycles) up to a maximum length
 #'
+#' For each vertex v, finds all simple out-paths from v (up to max_length hops)
+#' and keeps those whose terminal vertex has a direct edge back to v — i.e. the
+#' path closes a cycle.  Duplicate cycles (same set of vertices, different
+#' starting vertex) are suppressed by only recording a cycle when v equals the
+#' lexicographically smallest vertex name in the cycle.
+#'
+#' NOTE: `igraph::all_simple_paths(from = v, to = v)` always returns an empty
+#' set because igraph requires `from != to`.  The previous implementation
+#' relied on that call and therefore always returned zero cycles (L16 bug).
+#'
 #' @param graph igraph directed graph
-#' @param max_length integer maximum cycle length
-#' @return data.frame of cycles (path strings)
+#' @param max_length integer maximum cycle length (number of edges, not nodes)
+#' @return data.frame with one column `path` (character strings, e.g. "A->B->C->A")
 detect_feedback_loops <- function(graph, max_length = 5) {
-  if (!inherits(graph, "igraph")) return(list())
-  nodes <- igraph::V(graph)$name
-  result <- data.frame(path = character(0))
-  for (v in nodes) {
-    paths <- igraph::all_simple_paths(graph, from = v, to = v, mode = "out", cutoff = max_length)
+  if (!inherits(graph, "igraph")) return(data.frame(path = character(0)))
+  node_names <- igraph::V(graph)$name
+  result <- data.frame(path = character(0), stringsAsFactors = FALSE)
+
+  for (v in node_names) {
+    # Find all simple out-paths from v of length 1..(max_length-1) edges.
+    # cutoff is the number of *edges*, so cutoff = max_length - 1 limits path
+    # length to max_length nodes including the start (which is the convention
+    # used by the rest of the app — a "3-cycle" has 3 nodes).
+    paths <- igraph::all_simple_paths(graph, from = v, mode = "out",
+                                      cutoff = max_length - 1L)
+
     for (p in paths) {
-      if (length(p) > 1) {
-        path_str <- paste(igraph::V(graph)$name[as.numeric(p)], collapse = "->")
-        result <- rbind(result, data.frame(path = path_str))
-      }
+      if (length(p) < 2L) next            # need at least 2 nodes
+      path_names <- igraph::V(graph)$name[as.numeric(p)]
+      last_node  <- path_names[length(path_names)]
+
+      # Check whether the last node has a direct edge back to v (closes cycle)
+      if (!igraph::are_adjacent(graph, last_node, v)) next
+
+      # De-duplicate: only record the cycle when v is the lexicographically
+      # smallest vertex in the cycle (canonical representative).
+      if (v != min(path_names)) next
+
+      path_str <- paste(c(path_names, v), collapse = "->")
+      result <- rbind(result, data.frame(path = path_str, stringsAsFactors = FALSE))
     }
   }
   result

--- a/MarineSABRES_SES_Shiny/functions/persistent_storage.R
+++ b/MarineSABRES_SES_Shiny/functions/persistent_storage.R
@@ -196,12 +196,21 @@ set_projects_folder <- function(folder_path) {
 
   # Create folder if it doesn't exist
   if (!dir.exists(folder_path)) {
-    tryCatch({
-      dir.create(folder_path, recursive = TRUE)
-      debug_log(sprintf("Created projects folder: %s", folder_path), "PERSISTENT_STORAGE")
+    ok <- tryCatch({
+      dir.create(folder_path, recursive = TRUE, showWarnings = FALSE)
+      dir.exists(folder_path)
     }, error = function(e) {
-      return(list(success = FALSE, error = paste("Cannot create folder:", e$message)))
+      if (exists("debug_log", mode = "function")) {
+        debug_log(sprintf("set_projects_folder: %s", conditionMessage(e)), "STORAGE-ERROR")
+      }
+      FALSE
     })
+    if (!isTRUE(ok)) {
+      return(list(success = FALSE, error = "Could not create projects folder"))
+    }
+    if (exists("debug_log", mode = "function")) {
+      debug_log(sprintf("Created projects folder: %s", folder_path), "PERSISTENT_STORAGE")
+    }
   }
 
   # Create README file

--- a/MarineSABRES_SES_Shiny/global.R
+++ b/MarineSABRES_SES_Shiny/global.R
@@ -177,6 +177,34 @@ VERSION_INFO <- tryCatch({
 })
 
 # ============================================================================
+# DEBUG MODE CONFIGURATION (defined early: used by the i18n block below)
+# ============================================================================
+
+# Enable/disable debug logging via environment variable
+# Set MARINESABRES_DEBUG=TRUE in .Renviron or before running the app to enable debug logs
+# Default is FALSE for production use
+DEBUG_MODE <- Sys.getenv("MARINESABRES_DEBUG", "FALSE") == "TRUE"
+ADMIN_MODE <- Sys.getenv("MARINESABRES_ADMIN_MODE", "FALSE") == "TRUE"
+
+#' Debug logging helper function
+#'
+#' Conditionally prints debug messages based on DEBUG_MODE flag.
+#' In production (DEBUG_MODE=FALSE), these calls are silently skipped.
+#'
+#' @param message Character string to log
+#' @param context Optional context string (e.g., "TEMPLATE", "NETWORK_ANALYSIS")
+#' @export
+debug_log <- function(message, context = NULL) {
+  if (DEBUG_MODE) {
+    if (!is.null(context)) {
+      cat(sprintf("[%s] %s\n", context, message))
+    } else {
+      cat(message, "\n")
+    }
+  }
+}
+
+# ============================================================================
 # INTERNATIONALIZATION (i18n) CONFIGURATION
 # ============================================================================
 
@@ -413,33 +441,7 @@ AVAILABLE_LANGUAGES <- list(
 # Note: local = FALSE makes constants available globally
 source("constants.R", local = FALSE)
 
-# ============================================================================
-# DEBUG MODE CONFIGURATION (must be early for use by other modules)
-# ============================================================================
-
-# Enable/disable debug logging via environment variable
-# Set MARINESABRES_DEBUG=TRUE in .Renviron or before running the app to enable debug logs
-# Default is FALSE for production use
-DEBUG_MODE <- Sys.getenv("MARINESABRES_DEBUG", "FALSE") == "TRUE"
-ADMIN_MODE <- Sys.getenv("MARINESABRES_ADMIN_MODE", "FALSE") == "TRUE"
-
-#' Debug logging helper function
-#'
-#' Conditionally prints debug messages based on DEBUG_MODE flag.
-#' In production (DEBUG_MODE=FALSE), these calls are silently skipped.
-#'
-#' @param message Character string to log
-#' @param context Optional context string (e.g., "TEMPLATE", "NETWORK_ANALYSIS")
-#' @export
-debug_log <- function(message, context = NULL) {
-  if (DEBUG_MODE) {
-    if (!is.null(context)) {
-      cat(sprintf("[%s] %s\n", context, message))
-    } else {
-      cat(message, "\n")
-    }
-  }
-}
+# debug_log is defined earlier (load-order: used by the i18n block)
 
 #' P1 FIX: Startup Log Function
 #'
@@ -904,7 +906,7 @@ if (ML_ENABLED) {
 
 # ============================================================================
 # DEBUG MODE STATUS MESSAGE
-# (DEBUG_MODE and debug_log() defined earlier, after constants.R)
+# (DEBUG_MODE and debug_log() defined earlier, before the i18n block)
 # ============================================================================
 
 # Print debug mode status on startup

--- a/MarineSABRES_SES_Shiny/modules/import_data_module.R
+++ b/MarineSABRES_SES_Shiny/modules/import_data_module.R
@@ -606,7 +606,7 @@ import_data_server <- function(id, project_data_reactive, i18n, parent_session =
 
       # Navigate to dashboard using parent session if provided
       if (!is.null(parent_session)) {
-        updateTabItems(session = parent_session, "tabs", "dashboard")
+        updateTabItems(session = parent_session, "sidebar_menu", "dashboard")
       }
     }
 

--- a/MarineSABRES_SES_Shiny/modules/ses_models_module.R
+++ b/MarineSABRES_SES_Shiny/modules/ses_models_module.R
@@ -655,6 +655,6 @@ perform_ses_model_import <- function(isa_data, elements, connections,
 
   # Navigate to dashboard
   if (!is.null(parent_session)) {
-    updateTabItems(session = parent_session, "tabs", "dashboard")
+    updateTabItems(session = parent_session, "sidebar_menu", "dashboard")
   }
 }

--- a/MarineSABRES_SES_Shiny/modules/template_ses_module.R
+++ b/MarineSABRES_SES_Shiny/modules/template_ses_module.R
@@ -30,14 +30,14 @@ source(get_project_file("functions/template_loader.R"), local = TRUE)
   tryCatch({
     result <- load_all_templates("data")
     if (is.null(result) || length(result) == 0) {
-      debug_log("Warning: No templates loaded from data directory", "TEMPLATE", "WARN")
+      debug_log("Warning: No templates loaded from data directory", "TEMPLATE-WARN")
       list()
     } else {
       debug_log(sprintf("Loaded %d templates: %s", length(result), paste(names(result), collapse=", ")), "TEMPLATE")
       result
     }
   }, error = function(e) {
-    debug_log(paste("Error loading templates:", e$message), "TEMPLATE", "ERROR")
+    debug_log(paste("Error loading templates:", e$message), "TEMPLATE-ERROR")
     list()
   })
 }

--- a/MarineSABRES_SES_Shiny/server/export_handlers.R
+++ b/MarineSABRES_SES_Shiny/server/export_handlers.R
@@ -122,7 +122,7 @@ setup_export_handlers <- function(input, output, session, project_data, i18n) {
 
         showNotification(i18n$t("common.messages.data_exported_successfully"), type = "message")
       }, error = function(e) {
-        debug_log(paste("Data export error:", e$message), "EXPORT", "ERROR")
+        debug_log(paste("Data export error:", e$message), "EXPORT-ERROR")
         showNotification(
           paste(i18n$t("common.messages.export_failed"), e$message),
           type = "error",
@@ -236,7 +236,7 @@ setup_export_handlers <- function(input, output, session, project_data, i18n) {
 
         showNotification(i18n$t("common.messages.visualization_exported_successfully"), type = "message")
       }, error = function(e) {
-        debug_log(paste("Visualization export error:", e$message), "EXPORT", "ERROR")
+        debug_log(paste("Visualization export error:", e$message), "EXPORT-ERROR")
         # Ensure graphics device is closed on error
         tryCatch(dev.off(), error = function(e2) NULL)
         showNotification(

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-debug-log-arity.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-debug-log-arity.R
@@ -1,0 +1,6 @@
+test_that("no debug_log call passes a 3rd severity arg", {
+  files <- c("server/export_handlers.R", "modules/template_ses_module.R")
+  hit <- function(f) grep('debug_log\\(.*,\\s*"(ERROR|WARN|INFO)"\\)\\s*$',
+                          readLines(testthat::test_path("..", "..", f), warn = FALSE), perl = TRUE)
+  for (f in files) expect_length(hit(f), 0)
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-debug-log-load-order.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-debug-log-load-order.R
@@ -1,0 +1,8 @@
+test_that("debug_log is defined before it is first called in global.R", {
+  src  <- readLines(testthat::test_path("..", "..", "global.R"), warn = FALSE)
+  def  <- grep("^debug_log <- function", src)[1]
+  uses <- grep("debug_log\\(", src)
+  first_use <- min(setdiff(uses, def))
+  expect_true(!is.na(def) && def < first_use,
+              info = sprintf("def at %s, first use at %s", def, first_use))
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-network-analysis.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-network-analysis.R
@@ -653,12 +653,12 @@ test_that("build_network_from_isa creates igraph from valid isa", {
     nodes = data.frame(
       id = c("A", "B"),
       label = c("A", "B")
-      
+
     ),
     edges = data.frame(
       from = c("A"),
       to = c("B")
-      
+
     )
   )
 
@@ -666,4 +666,25 @@ test_that("build_network_from_isa creates igraph from valid isa", {
   expect_true(inherits(g, "igraph"))
   expect_equal(igraph::vcount(g), 2)
   expect_equal(igraph::ecount(g), 1)
+})
+
+# ============================================================================
+# detect_feedback_loops tests (L16)
+# ============================================================================
+
+test_that("detect_feedback_loops finds a simple 3-cycle (L16)", {
+  skip_if_not(exists("detect_feedback_loops", mode = "function"))
+  g <- igraph::graph_from_data_frame(
+    data.frame(from = c("A","B","C"), to = c("B","C","A")), directed = TRUE)
+  res <- detect_feedback_loops(g, max_length = 5)
+  expect_true(!is.null(res))
+  expect_gt(NROW(res), 0)
+})
+
+test_that("detect_feedback_loops returns empty for an acyclic graph (L16)", {
+  skip_if_not(exists("detect_feedback_loops", mode = "function"))
+  g <- igraph::graph_from_data_frame(
+    data.frame(from = c("A","B"), to = c("B","C")), directed = TRUE)
+  res <- detect_feedback_loops(g, max_length = 5)
+  expect_equal(NROW(res), 0)
 })

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-persistent-storage.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-persistent-storage.R
@@ -403,6 +403,17 @@ test_that("set_projects_folder rejects empty string", {
   expect_false(result$success)
 })
 
+test_that("set_projects_folder reports failure when the dir cannot be created", {
+  skip_if_not(exists("set_projects_folder", mode = "function"),
+              "set_projects_folder not available")
+  # A regular file used as a parent directory => dir.create() will fail
+  blocker <- tempfile()
+  writeLines("x", blocker)
+  on.exit(unlink(blocker), add = TRUE)
+  res <- set_projects_folder(file.path(blocker, "sub", "projects"))
+  expect_false(isTRUE(res$success))
+})
+
 # ============================================================================
 # find_recoverable_autosaves TESTS
 # ============================================================================

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-update-tab-items-id.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-update-tab-items-id.R
@@ -1,0 +1,8 @@
+test_that("no updateTabItems call uses the non-existent 'tabs' id", {
+  root  <- testthat::test_path("..", "..")
+  files <- list.files(root, pattern = "\\.R$", recursive = TRUE, full.names = TRUE)
+  files <- files[grepl("/(modules|server)/", files)]
+  bad <- unlist(lapply(files, function(f)
+    grep('updateTabItems\\([^)]*"tabs"', readLines(f, warn = FALSE), value = TRUE)))
+  expect_length(bad, 0)
+})


### PR DESCRIPTION
Phase A of the triaged fix plan (`docs/superpowers/plans/2026-06-03-codebase-review-fixes.md`). Five independent, low-risk fixes, each TDD (failing test → fix → green) and reviewed (spec + quality) via subagent-driven development.

| Finding | Fix | Test |
|---|---|---|
| **H4** | `debug_log` (+DEBUG_MODE/ADMIN_MODE) defined **before** the i18n block in `global.R` — fixes boot crash on `USE_MODULAR_TRANSLATIONS=FALSE` / `DEBUG_I18N=TRUE` | `test-debug-log-load-order.R` (static load-order) |
| **M1** | drop 3rd severity arg from 4 `debug_log()` calls (signature has no `...`) — folded into context string | `test-debug-log-arity.R` (paren-crossing regex, verified to match pre-fix) |
| **M13** | `updateTabItems` inputId `"tabs"`→`"sidebar_menu"` at import_data_module.R:609 **and** ses_models_module.R:658 — post-import nav was a silent no-op (id only; destination unchanged) | `test-update-tab-items-id.R` (greps all modules/server) |
| **M7** | `set_projects_folder` no longer returns false success — failure now returns from the outer fn before `saveRDS` | `test-persistent-storage.R` |
| **L16** | `detect_feedback_loops` returns real cycles (`all_simple_paths(from=v,to=v)` was always empty) — out-paths + back-edge filter, deduped by lex-min vertex; return contract preserved | `test-network-analysis.R` (3-cycle + acyclic) |

**Verification:** new tests pass; regressions green — global-utils 147, integration 56, network-analysis 138, persistent-storage 66, export-functions 16, recent-projects 15 (0 fails). No deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed feedback loop detection in network analysis that was incorrectly returning no results.
  * Corrected post-import navigation routing to direct users to the correct dashboard location.
  * Enhanced error handling for projects folder creation with improved failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->