### PR TITLE
fix(security): Phase C file-access containment (M6, M5, L10, L11)

### DIFF
--- a/MarineSABRES_SES_Shiny/modules/analysis_bot.R
+++ b/MarineSABRES_SES_Shiny/modules/analysis_bot.R
@@ -438,7 +438,7 @@ analysis_bot_server <- function(id, project_data_reactive, i18n, event_bus = NUL
     # Download handler
     output$download_bot_data <- downloadHandler(
       filename = function() {
-        generate_export_filename(paste0("BOT_Data_", input$bot_element), ".csv")
+        generate_export_filename(paste0("BOT_Data_", sanitize_filename(input$bot_element %||% "")), ".csv")
       },
       content = function(file) {
         write.csv(bot_rv$timeseries_data, file, row.names = FALSE)

--- a/MarineSABRES_SES_Shiny/modules/guidebook_module.R
+++ b/MarineSABRES_SES_Shiny/modules/guidebook_module.R
@@ -1,11 +1,35 @@
 # modules/guidebook_module.R
 # Guidebook module - displays the user guidebook in-app and provides download links
 
-# Resolve language-specific guidebook path with English fallback
+# Resolve language-specific guidebook path with English fallback.
+# Containment guard: even if a malformed language code slips through the modal
+# validator (defense-in-depth), we verify the resolved path stays inside the
+# guidebook/ directory before returning it.  A traversal like "../modules/evil"
+# would otherwise reach rmarkdown::render() and execute arbitrary R chunks.
 resolve_guidebook_rmd <- function(i18n) {
   lang <- tryCatch(i18n$get_translation_language(), error = function(e) "en")
   rmd_file <- file.path("guidebook", paste0("guidebook_", lang, ".Rmd"))
-  if (!file.exists(rmd_file)) {
+
+  # Normalize both the candidate path and the allowed base directory so that
+  # ".." components are resolved on Windows and Unix alike.  mustWork = FALSE
+  # is required because the language-specific file may not yet exist on disk.
+  guidebook_base <- normalizePath("guidebook", mustWork = FALSE)
+  rmd_normalized  <- normalizePath(rmd_file,  mustWork = FALSE)
+
+  # Containment check: the resolved candidate must start with the guidebook dir.
+  # If it escapes (traversal) or if the file simply doesn't exist, fall back to
+  # the English edition which is guaranteed to be present.
+  path_contained <- startsWith(rmd_normalized, guidebook_base)
+  if (!path_contained || !file.exists(rmd_file)) {
+    if (!path_contained) {
+      # Log at SECURITY level so operators can detect probing attempts.
+      debug_log(
+        paste0("resolve_guidebook_rmd: path traversal detected for lang='",
+               lang, "' — resolved to '", rmd_normalized,
+               "', outside guidebook base '", guidebook_base, "'. Falling back to en."),
+        "SECURITY"
+      )
+    }
     rmd_file <- file.path("guidebook", "guidebook_en.Rmd")
   }
   rmd_file

--- a/MarineSABRES_SES_Shiny/modules/ses_models_module.R
+++ b/MarineSABRES_SES_Shiny/modules/ses_models_module.R
@@ -3,6 +3,74 @@
 # Purpose: Load pre-built SES models from Excel files in the SESModels directory
 
 # ============================================================================
+# SECURITY HELPERS (M5: arbitrary-file-read containment)
+# ============================================================================
+
+#' Check that a candidate file path is strictly inside an allowed root directory.
+#'
+#' Both paths are normalised before comparison so that ".." traversal attacks
+#' and relative-path tricks are neutralised.  The check is fail-closed: any
+#' error in normalisation returns FALSE.
+#'
+#' @param candidate Character(1). Absolute or relative path to validate.
+#' @param root      Character(1). The allowed root directory.
+#' @return Logical scalar: TRUE only if \code{candidate} is inside \code{root}.
+ses_model_path_is_contained <- function(candidate, root) {
+  # Fail-closed on NULL / NA / empty inputs
+  if (is.null(candidate) || length(candidate) != 1 ||
+      is.na(candidate) || !nzchar(candidate)) return(FALSE)
+  if (is.null(root) || length(root) != 1 ||
+      is.na(root) || !nzchar(root)) return(FALSE)
+
+  safe_root <- tryCatch(
+    normalizePath(root,      winslash = "/", mustWork = FALSE),
+    error = function(e) NA_character_
+  )
+  norm_cand <- tryCatch(
+    normalizePath(candidate, winslash = "/", mustWork = FALSE),
+    error = function(e) NA_character_
+  )
+  if (is.na(safe_root) || is.na(norm_cand)) return(FALSE)
+
+  # Append trailing slash so "rootX/ok.xlsx" is not accepted when root is "root"
+  startsWith(norm_cand, paste0(safe_root, "/")) ||
+    norm_cand == safe_root
+}
+
+#' Check that a candidate file path is present in the previously scanned set.
+#'
+#' This is the primary (whitelist) containment gate: if the value sent by the
+#' WebSocket client is not one of the file paths we obtained by scanning the
+#' models directory ourselves, we refuse to open it.
+#'
+#' Both the candidate and every entry in \code{scanned} are normalised to
+#' forward-slash form before comparison so that Windows short-vs-long path or
+#' backslash/forward-slash differences cannot defeat the check.
+#'
+#' @param candidate  Character(1). Path to validate.
+#' @param scanned    Character vector. File paths from the last scan (may be
+#'   already normalised or not — this function normalises them).
+#' @return Logical scalar.
+ses_model_path_is_in_scanned_set <- function(candidate, scanned) {
+  if (is.null(candidate) || length(candidate) != 1 ||
+      is.na(candidate) || !nzchar(candidate)) return(FALSE)
+  if (length(scanned) == 0) return(FALSE)
+
+  norm_cand <- tryCatch(
+    normalizePath(candidate, winslash = "/", mustWork = FALSE),
+    error = function(e) NA_character_
+  )
+  if (is.na(norm_cand)) return(FALSE)
+
+  norm_scanned <- vapply(scanned, function(p) {
+    tryCatch(normalizePath(p, winslash = "/", mustWork = FALSE),
+             error = function(e) NA_character_)
+  }, character(1), USE.NAMES = FALSE)
+
+  norm_cand %in% norm_scanned
+}
+
+# ============================================================================
 # UI FUNCTION
 # ============================================================================
 
@@ -315,7 +383,54 @@ ses_models_server <- function(id, project_data_reactive, i18n, parent_session = 
     # Update preview when selection changes
     observeEvent(input$model_select, {
       req(input$model_select)
-      rv$selected_model_path <- input$model_select
+
+      # ── Security (M5): validate candidate against the scanned whitelist ──────
+      # The selectInput value arrives over the WebSocket and must not be trusted
+      # as a safe file path without verification.  We apply two complementary
+      # checks (both must pass when the scan has already run):
+      #   1. Whitelist: the path must be in rv$models_grouped (scanned set).
+      #   2. Root containment: the normalised path must sit inside the active
+      #      models directory (defence-in-depth even if rv$models_grouped is
+      #      somehow empty on the first trigger before a scan completes).
+      candidate <- input$model_select
+
+      # Build the scanned whitelist from rv$models_grouped
+      scanned_paths <- character(0)
+      if (!is.null(rv$models_grouped) && length(rv$models_grouped) > 0) {
+        scanned_paths <- unlist(lapply(rv$models_grouped, function(grp) {
+          vapply(grp, function(m) m$file_path, character(1))
+        }), use.names = FALSE)
+      }
+
+      # Determine the active models root so we can apply containment even
+      # before the first scan result is available.
+      models_root <- tryCatch(
+        normalizePath(get_models_dir(), winslash = "/", mustWork = FALSE),
+        error = function(e) NA_character_
+      )
+
+      whitelist_ok   <- length(scanned_paths) > 0 &&
+                          ses_model_path_is_in_scanned_set(candidate, scanned_paths)
+      containment_ok <- !is.na(models_root) &&
+                          ses_model_path_is_contained(candidate, models_root)
+
+      # If the scan has run: require whitelist membership.
+      # If the scan has NOT yet run (scanned_paths is empty): fall back to
+      # containment-only (load_models_on_demand() fires in the prior observer).
+      path_is_safe <- if (length(scanned_paths) > 0) whitelist_ok else containment_ok
+
+      if (!path_is_safe) {
+        debug_log(sprintf("[security] Rejected model_select value outside models root: '%s' (root=%s)",
+                          candidate, if (is.na(models_root)) "NA" else models_root),
+                  "SES_MODELS")
+        rv$selected_model_path <- NULL
+        rv$selected_model_info <- NULL
+        rv$preview_data        <- NULL
+        return()
+      }
+      # ── End security check ───────────────────────────────────────────────────
+
+      rv$selected_model_path <- candidate
       rv$selected_variant <- NULL  # Reset variant selection
 
       # Find full model info from grouped models
@@ -485,6 +600,30 @@ ses_models_server <- function(id, project_data_reactive, i18n, parent_session = 
     # Confirm Yes - load the model
     observeEvent(input$confirm_yes, {
       req(rv$selected_model_path)
+
+      # ── Security (M5) defence-in-depth: re-validate path before opening ──────
+      # rv$selected_model_path was validated when model_select fired, but we
+      # perform a final containment check here as an extra layer of defence.
+      models_root <- tryCatch(
+        normalizePath(get_models_dir(), winslash = "/", mustWork = FALSE),
+        error = function(e) NA_character_
+      )
+      if (is.na(models_root) ||
+          !ses_model_path_is_contained(rv$selected_model_path, models_root)) {
+        debug_log(sprintf("[security] Blocked model load — path outside models root: '%s' (root=%s)",
+                          rv$selected_model_path,
+                          if (is.na(models_root)) "NA" else models_root),
+                  "SES_MODELS")
+        showNotification(
+          i18n$t("modules.ses_models.model_not_found"),
+          type = "error", duration = 5
+        )
+        rv$selected_model_path <- NULL
+        rv$selected_model_info <- NULL
+        rv$preview_data        <- NULL
+        return()
+      }
+      # ── End security check ───────────────────────────────────────────────────
 
       # Close modal
       toggleModal(session, "confirm_modal", toggle = "close")

--- a/MarineSABRES_SES_Shiny/server/modals.R
+++ b/MarineSABRES_SES_Shiny/server/modals.R
@@ -562,16 +562,29 @@ setup_language_modal_only <- function(input, output, session, i18n, AVAILABLE_LA
     } else if (input$ses_models_source == "custom" && !is.null(input$ses_models_custom_path)) {
       custom_path <- input$ses_models_custom_path
       if (nzchar(custom_path)) {
-        if (dir.exists(custom_path)) {
-          ses_models_directory(custom_path)
-          debug_log(sprintf("SES Models directory set to: %s", custom_path), "SETTINGS")
-          settings_changed <- TRUE
-          invalidate_ses_models_cache()
-        } else {
+        # Normalise the client-supplied path before storing it.
+        # This neutralises any ".." traversal in the value and gives us an
+        # absolute canonical path so that the per-file containment check in
+        # ses_models_module.R works correctly regardless of working directory.
+        norm_custom <- tryCatch(
+          normalizePath(custom_path, winslash = "/", mustWork = FALSE),
+          error = function(e) NULL
+        )
+        if (is.null(norm_custom) || !nzchar(norm_custom)) {
           showNotification(
             paste(i18n$t("ui.modals.directory_not_found"), custom_path),
             type = "error", duration = 5
           )
+        } else if (!dir.exists(norm_custom)) {
+          showNotification(
+            paste(i18n$t("ui.modals.directory_not_found"), norm_custom),
+            type = "error", duration = 5
+          )
+        } else {
+          ses_models_directory(norm_custom)
+          debug_log(sprintf("SES Models directory set to: %s", norm_custom), "SETTINGS")
+          settings_changed <- TRUE
+          invalidate_ses_models_cache()
         }
       }
     }

--- a/MarineSABRES_SES_Shiny/server/modals.R
+++ b/MarineSABRES_SES_Shiny/server/modals.R
@@ -69,6 +69,21 @@ setup_language_modal_only <- function(input, output, session, i18n, AVAILABLE_LA
 
     new_lang <- input$language_selector
 
+    # Security: validate that the client-supplied language code is one of the
+    # declared valid codes.  A tampered WebSocket message could otherwise inject
+    # a path-traversal string that propagates into file-path construction (e.g.,
+    # resolve_guidebook_rmd) and ultimately into rmarkdown::render() — RCE risk.
+    if (!(new_lang %in% names(AVAILABLE_LANGUAGES))) {
+      debug_log(paste("Language change rejected: unknown code:", new_lang), "SECURITY")
+      showNotification(
+        i18n$t("common.messages.invalid_language_code"),
+        type = "warning",
+        duration = 5,
+        session = session
+      )
+      return()
+    }
+
     debug_log(paste("Language changed to:", new_lang), "LANGUAGE")
 
     # Close the modal first

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-c3-hardening.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-c3-hardening.R
@@ -1,0 +1,160 @@
+# tests/testthat/test-c3-hardening.R
+# Task C3: Security hardening tests for L10 (filename injection) and L11 (i18n HTML escaping)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+source_utils <- function() {
+  utils_path <- testthat::test_path("../../functions/utils.R")
+  if (file.exists(utils_path)) {
+    source(utils_path, local = FALSE)
+  }
+}
+
+# ---------------------------------------------------------------------------
+# L10 — sanitize_filename contract + static assertion on analysis_bot.R
+# ---------------------------------------------------------------------------
+
+test_that("sanitize_filename strips header-injection chars (double-quote and newline)", {
+  source_utils()
+  skip_if_not(exists("sanitize_filename", mode = "function"),
+              "sanitize_filename not found after sourcing utils.R")
+  # Build a string with actual double-quote and actual newline characters
+  evil_name <- paste0("evil", '"', "\nX-Inject: 1")
+  out <- sanitize_filename(evil_name)
+  expect_false(grepl('"', out, fixed = TRUE),
+               info = paste("double-quote still present in output:", out))
+  expect_false(grepl("\n", out, fixed = TRUE),
+               info = paste("newline still present in output:", out))
+  expect_false(grepl("\r", out, fixed = TRUE),
+               info = paste("carriage-return still present in output:", out))
+})
+
+test_that("sanitize_filename strips carriage return", {
+  source_utils()
+  skip_if_not(exists("sanitize_filename", mode = "function"),
+              "sanitize_filename not found")
+  out <- sanitize_filename("name\rwith\rCR")
+  expect_false(grepl("\r", out, fixed = TRUE),
+               info = paste("CR still present in output:", out))
+})
+
+test_that("sanitize_filename returns non-empty string for empty/NULL input", {
+  source_utils()
+  skip_if_not(exists("sanitize_filename", mode = "function"),
+              "sanitize_filename not found")
+  expect_true(nchar(sanitize_filename("")) > 0)
+  expect_true(nchar(sanitize_filename(NULL)) > 0)
+})
+
+test_that("bot download filename sanitizes the element name (static source check)", {
+  bot_path <- testthat::test_path("../../modules/analysis_bot.R")
+  skip_if_not(file.exists(bot_path), "modules/analysis_bot.R not found")
+  src <- paste(readLines(bot_path, warn = FALSE), collapse = "\n")
+  expect_true(
+    grepl("sanitize_filename\\(input\\$bot_element", src) ||
+      grepl("sanitize_filename\\([^)]*bot_element", src),
+    label = "analysis_bot.R download filename must call sanitize_filename(input$bot_element)"
+  )
+})
+
+# ---------------------------------------------------------------------------
+# L11 — HTML(i18n$t) audit: assert leverage and simplify sites are intentional
+# ---------------------------------------------------------------------------
+
+# For the leverage and simplify modules, all HTML(i18n$t(...)) sites render
+# translation strings that INTENTIONALLY contain HTML markup (<strong>, <em>).
+# Escaping them would break rendered output for all 9 language users.
+# These are authored strings in version-controlled JSON files, NOT user input.
+# Therefore they are LEFT as HTML(i18n$t(...)) and documented here.
+#
+# This test asserts that:
+# 1. The leverage module's HTML(i18n$t) sites are only for the known-markup keys.
+# 2. The simplify module's HTML(i18n$t) sites are only for the known-markup keys.
+# 3. No NEW HTML(i18n$t) sites have been added to these files without review.
+# analysis_loops.R had no HTML(i18n$t) sites (confirmed by grep).
+
+test_that("analysis_leverage.R HTML(i18n$t) sites are limited to known-markup keys", {
+  leverage_path <- testthat::test_path("../../modules/analysis_leverage.R")
+  skip_if_not(file.exists(leverage_path), "modules/analysis_leverage.R not found")
+
+  src <- paste(readLines(leverage_path, warn = FALSE), collapse = "\n")
+  # Extract all keys used in HTML(i18n$t("...")) calls
+  matches <- gregexpr('HTML\\(i18n\\$t\\("([^"]+)"\\)', src, perl = TRUE)
+  raw_matches <- regmatches(src, matches)[[1]]
+  keys_used <- if (length(raw_matches) > 0) {
+    sub('.*HTML\\(i18n\\$t\\("([^"]+)"\\).*', "\\1", raw_matches, perl = TRUE)
+  } else {
+    character(0)
+  }
+
+  known_markup_keys <- c(
+    "modules.analysis.leverage.no_network_data",
+    "modules.analysis.leverage.click_calculate"
+  )
+
+  unexpected <- setdiff(keys_used, known_markup_keys)
+  expect_equal(
+    length(unexpected), 0L,
+    label = paste(
+      "Unexpected HTML(i18n$t) site(s) found in analysis_leverage.R.",
+      "If intentional (markup in translations), add the key to known_markup_keys.",
+      "Keys:", paste(unexpected, collapse = ", ")
+    )
+  )
+})
+
+test_that("analysis_simplify.R HTML(i18n$t) sites are limited to known-markup keys", {
+  simplify_path <- testthat::test_path("../../modules/analysis_simplify.R")
+  skip_if_not(file.exists(simplify_path), "modules/analysis_simplify.R not found")
+
+  src <- paste(readLines(simplify_path, warn = FALSE), collapse = "\n")
+  matches <- gregexpr('HTML\\(i18n\\$t\\("([^"]+)"\\)', src, perl = TRUE)
+  raw_matches <- regmatches(src, matches)[[1]]
+  keys_used <- if (length(raw_matches) > 0) {
+    sub('.*HTML\\(i18n\\$t\\("([^"]+)"\\).*', "\\1", raw_matches, perl = TRUE)
+  } else {
+    character(0)
+  }
+
+  known_markup_keys <- c(
+    "modules.analysis.simplify.about_better_communication",
+    "modules.analysis.simplify.about_focused_analysis",
+    "modules.analysis.simplify.about_computational_efficiency",
+    "modules.analysis.simplify.about_pattern_recognition",
+    "modules.analysis.simplify.about_scenario_testing",
+    "modules.analysis.simplify.about_bp_feedback",
+    "modules.analysis.simplify.about_bp_causality",
+    "modules.analysis.simplify.about_bp_document",
+    "modules.analysis.simplify.about_bp_validate",
+    "modules.analysis.simplify.about_bp_multiple",
+    "modules.analysis.simplify.about_bp_iterate",
+    "modules.analysis.simplify.about_rec_internal",
+    "modules.analysis.simplify.about_rec_visual",
+    "modules.analysis.simplify.about_rec_leverage",
+    "modules.analysis.simplify.about_rec_sector",
+    "modules.analysis.simplify.about_rec_maximum"
+  )
+
+  unexpected <- setdiff(keys_used, known_markup_keys)
+  expect_equal(
+    length(unexpected), 0L,
+    label = paste(
+      "Unexpected HTML(i18n$t) site(s) found in analysis_simplify.R.",
+      "If intentional (markup in translations), add the key to known_markup_keys.",
+      "Keys:", paste(unexpected, collapse = ", ")
+    )
+  )
+})
+
+test_that("analysis_loops.R has no HTML(i18n$t) sites", {
+  loops_path <- testthat::test_path("../../modules/analysis_loops.R")
+  skip_if_not(file.exists(loops_path), "modules/analysis_loops.R not found")
+
+  src <- paste(readLines(loops_path, warn = FALSE), collapse = "\n")
+  expect_false(
+    grepl("HTML\\(i18n\\$t", src),
+    label = "analysis_loops.R should have no HTML(i18n$t) calls (confirmed none existed)"
+  )
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-language-path-containment.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-language-path-containment.R
@@ -1,0 +1,169 @@
+# tests/testthat/test-language-path-containment.R
+# Task C1 (M6) — security regression tests for the language-selector RCE fix.
+#
+# Two independent defences are tested:
+#  1. resolve_guidebook_rmd() path-containment (behavioral, directly callable)
+#  2. modals.R language-modal handler validates against AVAILABLE_LANGUAGES
+#     before calling set_translation_language (static source assertion — a
+#     testServer() approach is not practical here because setup_language_modal_only
+#     is shadowed by helper-stubs.R and needs heavy session wiring; the static
+#     assertion proves the guard is in the live source without running the server).
+
+# Load the guidebook module so resolve_guidebook_rmd is available.
+# source_for_test() is defined in helper-00-load-functions.R (always loaded
+# before test files by testthat's helper-file discovery).
+source_for_test("modules/guidebook_module.R")
+
+# ---------------------------------------------------------------------------
+# Minimal fake i18n: only get_translation_language() is needed by
+# resolve_guidebook_rmd.
+# ---------------------------------------------------------------------------
+fake_i18n <- function(lang) {
+  list(get_translation_language = function() lang)
+}
+
+# ---------------------------------------------------------------------------
+# 1. Path-containment tests for resolve_guidebook_rmd()
+# ---------------------------------------------------------------------------
+
+test_that("resolve_guidebook_rmd contains traversal language codes to the guidebook dir", {
+  skip_if_not(exists("resolve_guidebook_rmd", mode = "function"),
+              "resolve_guidebook_rmd not sourced")
+
+  # Simulate a path-traversal attack: language = "../modules/cld_visualization_module"
+  res <- resolve_guidebook_rmd(fake_i18n("../modules/cld_visualization_module"))
+
+  # The result must be a path inside guidebook/ and must look like a guidebook_ file.
+  expect_true(
+    grepl("guidebook[/\\\\]guidebook_", res, perl = TRUE),
+    info = paste("Expected path inside guidebook/guidebook_*, got:", res)
+  )
+
+  # It must NOT contain 'modules' — that would mean the traversal succeeded.
+  expect_false(
+    grepl("modules", res, ignore.case = TRUE),
+    info = paste("Path must not escape into modules/, got:", res)
+  )
+})
+
+test_that("resolve_guidebook_rmd blocks double-dot traversal with Windows separators", {
+  skip_if_not(exists("resolve_guidebook_rmd", mode = "function"),
+              "resolve_guidebook_rmd not sourced")
+
+  res <- resolve_guidebook_rmd(fake_i18n("..\\server\\project_io"))
+
+  expect_true(
+    grepl("guidebook[/\\\\]guidebook_", res, perl = TRUE),
+    info = paste("Expected path inside guidebook/guidebook_*, got:", res)
+  )
+  expect_false(
+    grepl("server", res, ignore.case = TRUE),
+    info = paste("Path must not escape into server/, got:", res)
+  )
+})
+
+test_that("resolve_guidebook_rmd returns the English guidebook for a valid language with no language file", {
+  skip_if_not(exists("resolve_guidebook_rmd", mode = "function"),
+              "resolve_guidebook_rmd not sourced")
+
+  # "en" always has a file (if guidebook/ is present); any valid code with no
+  # file also falls back to en.  Either way, path must be guidebook_en.Rmd.
+  res <- resolve_guidebook_rmd(fake_i18n("en"))
+
+  expect_true(
+    grepl("guidebook_en\\.Rmd$", res, perl = TRUE),
+    info = paste("Expected guidebook_en.Rmd, got:", res)
+  )
+})
+
+test_that("resolve_guidebook_rmd result always stays inside the guidebook directory", {
+  skip_if_not(exists("resolve_guidebook_rmd", mode = "function"),
+              "resolve_guidebook_rmd not sourced")
+
+  # A broad set of adversarial inputs — all must resolve inside guidebook/
+  adversarial_langs <- c(
+    "../modules/evil",
+    "../../etc/passwd",
+    "../server/project_io",
+    "en/../../../etc/shadow",
+    "/absolute/path/injected"
+  )
+
+  td <- getwd()
+  root <- if (basename(td) == "testthat") dirname(dirname(td)) else td
+  guidebook_base <- normalizePath(file.path(root, "guidebook"), mustWork = FALSE)
+
+  for (lang in adversarial_langs) {
+    res <- resolve_guidebook_rmd(fake_i18n(lang))
+    # Resolve the returned path relative to project root
+    res_abs <- normalizePath(file.path(root, res), mustWork = FALSE)
+    expect_true(
+      startsWith(res_abs, guidebook_base),
+      info = paste0("Adversarial lang='", lang, "' escaped to: ", res_abs)
+    )
+  }
+})
+
+# ---------------------------------------------------------------------------
+# 2. Static assertion: modals.R validates against AVAILABLE_LANGUAGES
+#    before calling set_translation_language
+# ---------------------------------------------------------------------------
+
+test_that("language modal validates input against AVAILABLE_LANGUAGES before setting", {
+  # This is a source-level regression test (see helper-source-grep.R for rationale).
+  # It asserts that BOTH the guard and the call to set_translation_language are
+  # present in the same file, proving the validation was not accidentally removed.
+  td <- getwd()
+  root <- if (basename(td) == "testthat") dirname(dirname(td)) else td
+  src <- paste(readLines(file.path(root, "server", "modals.R"), warn = FALSE),
+               collapse = "\n")
+
+  expect_true(
+    grepl("AVAILABLE_LANGUAGES", src, fixed = TRUE) &&
+      grepl("set_translation_language", src, fixed = TRUE),
+    info = "modals.R must reference AVAILABLE_LANGUAGES and set_translation_language"
+  )
+})
+
+test_that("language modal guard appears BEFORE set_translation_language in source order", {
+  td <- getwd()
+  root <- if (basename(td) == "testthat") dirname(dirname(td)) else td
+  lines <- readLines(file.path(root, "server", "modals.R"), warn = FALSE)
+
+  guard_line  <- which(grepl("AVAILABLE_LANGUAGES", lines, fixed = TRUE))
+  setter_line <- which(grepl("set_translation_language", lines, fixed = TRUE))
+
+  expect_true(length(guard_line)  >= 1, info = "AVAILABLE_LANGUAGES check not found in modals.R")
+  expect_true(length(setter_line) >= 1, info = "set_translation_language not found in modals.R")
+
+  # The first occurrence of the guard must precede the setter call.
+  expect_true(
+    min(guard_line) < min(setter_line),
+    info = paste0(
+      "AVAILABLE_LANGUAGES guard (line ", min(guard_line), ") must appear ",
+      "BEFORE set_translation_language (line ", min(setter_line), ")"
+    )
+  )
+})
+
+test_that("language modal guard returns early on invalid code", {
+  # Source-level check: the validation block must have both the guard condition
+  # and a return() — proving the handler bails out before set_translation_language.
+  td <- getwd()
+  root <- if (basename(td) == "testthat") dirname(dirname(td)) else td
+  lines <- readLines(file.path(root, "server", "modals.R"), warn = FALSE)
+
+  # Match the guard line: `if (!(new_lang %in% names(AVAILABLE_LANGUAGES)))`
+  # Use a broad pattern to survive whitespace/style variation.
+  guard_start <- which(grepl("new_lang.*AVAILABLE_LANGUAGES", lines, perl = TRUE))
+  expect_true(length(guard_start) >= 1,
+              info = "modals.R must contain a guard checking new_lang against AVAILABLE_LANGUAGES")
+
+  # Look for return() within 20 lines of the guard (the if-block body)
+  block_end   <- min(guard_start[1] + 20L, length(lines))
+  guard_block <- lines[seq(guard_start[1], block_end)]
+  expect_true(
+    any(grepl("return\\(\\)", guard_block, perl = TRUE)),
+    info = "The validation guard must return() early to prevent set_translation_language from executing"
+  )
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-ses-model-path-containment.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-ses-model-path-containment.R
@@ -1,0 +1,141 @@
+# test-ses-model-path-containment.R
+# Security tests for SES model path containment (M5: arbitrary file read)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Resolve the project root reliably whether run via test_file() or test_dir()
+.ses_containment_app_dir <- local({
+  d <- tryCatch(
+    normalizePath(file.path(testthat::test_path(), "..", ".."),
+                  winslash = "/", mustWork = FALSE),
+    error = function(e) NULL
+  )
+  if (is.null(d) || !file.exists(file.path(d, "app.R"))) {
+    d <- "C:/Users/arturas.baziukas/OneDrive - ku.lt/HORIZON_EUROPE/Marine-SABRES/SESToolbox/MarineSABRES_SES_Shiny"
+  }
+  d
+})
+
+# Source the module into .GlobalEnv so top-level helpers become available in
+# the test environment.  The module uses Shiny/bslib at the top-level only
+# inside function bodies, so sourcing it is safe when those packages are loaded
+# (which global.R already did via the helper chain).
+.source_ses_models_module_once <- local({
+  done <- FALSE
+  function() {
+    if (done) return(invisible(NULL))
+    module_path <- file.path(.ses_containment_app_dir, "modules", "ses_models_module.R")
+    if (!file.exists(module_path)) {
+      warning("ses_models_module.R not found; containment helper tests will skip")
+      return(invisible(NULL))
+    }
+    tryCatch(
+      source(module_path, local = FALSE),   # into .GlobalEnv
+      error = function(e) warning("Could not source ses_models_module.R: ", e$message)
+    )
+    done <<- TRUE
+    invisible(NULL)
+  }
+})
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_that("ses_model_path_is_contained exists after sourcing the module", {
+  .source_ses_models_module_once()
+  expect_true(exists("ses_model_path_is_contained", mode = "function",
+                     envir = .GlobalEnv))
+})
+
+test_that("a model path inside the models root is accepted", {
+  .source_ses_models_module_once()
+  skip_if_not(exists("ses_model_path_is_contained", mode = "function", envir = .GlobalEnv))
+
+  root   <- tempfile("modelsroot"); dir.create(root)
+  inside <- file.path(root, "ok.xlsx"); file.create(inside)
+  on.exit(unlink(c(root, inside), recursive = TRUE), add = TRUE)
+
+  expect_true(ses_model_path_is_contained(inside, root))
+})
+
+test_that("a model path outside the models root is rejected", {
+  .source_ses_models_module_once()
+  skip_if_not(exists("ses_model_path_is_contained", mode = "function", envir = .GlobalEnv))
+
+  root    <- tempfile("modelsroot"); dir.create(root)
+  inside  <- file.path(root, "ok.xlsx");          file.create(inside)
+  outside <- tempfile(fileext = ".xlsx");          file.create(outside)
+  on.exit(unlink(c(root, inside, outside), recursive = TRUE), add = TRUE)
+
+  expect_true( ses_model_path_is_contained(inside,  root))
+  expect_false(ses_model_path_is_contained(outside, root))
+})
+
+test_that("path traversal via .. is rejected", {
+  .source_ses_models_module_once()
+  skip_if_not(exists("ses_model_path_is_contained", mode = "function", envir = .GlobalEnv))
+
+  root <- tempfile("modelsroot"); dir.create(root)
+  on.exit(unlink(root, recursive = TRUE), add = TRUE)
+
+  # file.path(root, "..", "escape.xlsx") normalises to a sibling of root
+  escape <- file.path(root, "..", "escape.xlsx")
+  expect_false(ses_model_path_is_contained(escape, root))
+})
+
+test_that("NULL or empty candidate path is rejected", {
+  .source_ses_models_module_once()
+  skip_if_not(exists("ses_model_path_is_contained", mode = "function", envir = .GlobalEnv))
+
+  root <- tempfile("modelsroot"); dir.create(root)
+  on.exit(unlink(root, recursive = TRUE), add = TRUE)
+
+  expect_false(ses_model_path_is_contained(NULL,         root))
+  expect_false(ses_model_path_is_contained("",           root))
+  expect_false(ses_model_path_is_contained(NA_character_, root))
+})
+
+test_that("NULL or empty root causes rejection (fail-closed)", {
+  .source_ses_models_module_once()
+  skip_if_not(exists("ses_model_path_is_contained", mode = "function", envir = .GlobalEnv))
+
+  root   <- tempfile("modelsroot"); dir.create(root)
+  inside <- file.path(root, "ok.xlsx"); file.create(inside)
+  on.exit(unlink(c(root, inside), recursive = TRUE), add = TRUE)
+
+  expect_false(ses_model_path_is_contained(inside, NULL))
+  expect_false(ses_model_path_is_contained(inside, ""))
+})
+
+test_that("a scanned-whitelist check rejects an off-whitelist path", {
+  .source_ses_models_module_once()
+  skip_if_not(exists("ses_model_path_is_in_scanned_set", mode = "function",
+                     envir = .GlobalEnv))
+
+  root    <- tempfile("modelsroot"); dir.create(root)
+  # Use winslash="/" to match what ses_model_path_is_in_scanned_set produces
+  # internally (it calls normalizePath(..., winslash="/")).
+  allowed <- normalizePath(file.path(root, "valid.xlsx"), winslash = "/", mustWork = FALSE)
+  foreign <- normalizePath(tempfile(fileext = ".xlsx"),   winslash = "/", mustWork = FALSE)
+  on.exit(unlink(root, recursive = TRUE), add = TRUE)
+
+  expect_true( ses_model_path_is_in_scanned_set(allowed,  c(allowed)))
+  expect_false(ses_model_path_is_in_scanned_set(foreign,  c(allowed)))
+  expect_false(ses_model_path_is_in_scanned_set(NULL,     c(allowed)))
+  expect_false(ses_model_path_is_in_scanned_set(allowed,  character(0)))
+})
+
+# Sibling-prefix attack: a dir sharing the root's name prefix must be rejected.
+# This locks in the trailing-slash guard in ses_model_path_is_contained.
+test_that("sibling directory with shared prefix is rejected (trailing-slash guard)", {
+  .source_ses_models_module_once()
+  skip_if_not(exists("ses_model_path_is_contained", mode = "function"))
+  root    <- tempfile("models"); dir.create(root)
+  sibling <- paste0(root, "foo"); dir.create(sibling)   # same prefix, different dir
+  evil    <- file.path(sibling, "evil.xlsx"); file.create(evil)
+  on.exit(unlink(c(root, sibling), recursive = TRUE), add = TRUE)
+  expect_false(ses_model_path_is_contained(evil, root))
+})

--- a/MarineSABRES_SES_Shiny/translations/common/messages.json
+++ b/MarineSABRES_SES_Shiny/translations/common/messages.json
@@ -1155,6 +1155,17 @@
       "no": "gjenoppretter arbeidet ditt etter språkendringen",
       "el": "επαναφορά της εργασίας σας μετά την αλλαγή γλώσσας"
     },
+    "common.messages.invalid_language_code": {
+      "en": "Invalid language code. Please select a supported language.",
+      "es": "Código de idioma no válido. Por favor, seleccione un idioma compatible.",
+      "fr": "Code de langue invalide. Veuillez sélectionner une langue prise en charge.",
+      "de": "Ungültiger Sprachcode. Bitte wählen Sie eine unterstützte Sprache aus.",
+      "lt": "Neteisingas kalbos kodas. Prašome pasirinkti palaikomą kalbą.",
+      "pt": "Código de idioma inválido. Por favor, selecione um idioma suportado.",
+      "it": "Codice lingua non valido. Selezionare una lingua supportata.",
+      "no": "Ugyldig språkkode. Vennligst velg et støttet språk.",
+      "el": "Μη έγκυρος κωδικός γλώσσας. Παρακαλώ επιλέξτε μια υποστηριζόμενη γλώσσα."
+    },
     "common.messages.context_language_change_save": {
       "en": "saving your work before the language change",
       "es": "guardando su trabajo antes del cambio de idioma",

--- a/MarineSABRES_SES_Shiny/translations/modules/ses_models.json
+++ b/MarineSABRES_SES_Shiny/translations/modules/ses_models.json
@@ -275,6 +275,17 @@
       "no": "Ingen Excel-modeller funnet i SESModels-katalogen.",
       "el": "Όχι Excel models found in the SESModels directory."
     },
+    "modules.ses_models.model_not_found": {
+      "en": "Selected model could not be found or is outside the models directory.",
+      "es": "No se pudo encontrar el modelo seleccionado o está fuera del directorio de modelos.",
+      "fr": "Le modèle sélectionné est introuvable ou se trouve en dehors du répertoire des modèles.",
+      "de": "Das ausgewählte Modell wurde nicht gefunden oder liegt außerhalb des Modellverzeichnisses.",
+      "lt": "Pasirinkto modelio nepavyko rasti arba jis yra ne modelių kataloge.",
+      "pt": "O modelo selecionado não foi encontrado ou está fora do diretório de modelos.",
+      "it": "Il modello selezionato non è stato trovato o è esterno alla directory dei modelli.",
+      "no": "Den valgte modellen ble ikke funnet eller er utenfor modellkatalogen.",
+      "el": "Το επιλεγμένο μοντέλο δεν βρέθηκε ή βρίσκεται εκτός του καταλόγου μοντέλων."
+    },
     "modules.ses_models.select_variant": {
       "en": "Select Model Variant",
       "es": "Seleccionar Variante del Modelo",


### PR DESCRIPTION
Phase C of the fix plan — **P0 file-access security**. Stops client-controlled paths/lang codes from reaching the filesystem / `rmarkdown::render`. Each task TDD + independently reviewed (spec + quality) via subagent-driven development; security logic adversarially verified.

| # | Fix | Commit |
|---|---|---|
| **C1 (M6)** | Language modal validates `input$language_selector` against `names(AVAILABLE_LANGUAGES)` before `set_translation_language`; `resolve_guidebook_rmd` contains the `.Rmd` path inside `guidebook/` (`normalizePath`+`startsWith`, fallback en) → closes the `rmarkdown::render` traversal RCE. Adds the `common.messages.invalid_language_code` key ×9. | `563aa8c` |
| **C2 (M5)** | `ses_models` picker constrains the selected file to the **scanned whitelist** (+ `normalizePath`-prefix containment fallback + confirm-time re-check); custom dir normalized → closes arbitrary `.xlsx` read. | `8ca6b00` |
| **C3 (L10)** | bot CSV download filename wrapped in `sanitize_filename()` (Content-Disposition header-injection). | `22b3fa1` |
| **C3 (L11)** | audited all `HTML(i18n$t())` sites — all carry intentional `<strong>`/`<em>` markup with no user-input interpolation → accept-with-rationale (escaping would break the UI; exploit needs write access to translation files). | `22b3fa1` |

**Reviewer-verified exploit blocking:** the guidebook traversal (`../modules/...`), absolute/colon paths, and the ses-model sibling-prefix (`models` vs `modelsfoo`) bypass were all confirmed rejected.

**Verification:** containment tests 16+15+10, regressions clean (guidebook 23, ses-models-loader 174, modals 3); i18n key present ×9.

**Note:** the known flaky `test-ml-graph-features.R` *timing* assertion (`elapsed<2`, ~2.5s) is pre-existing/unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidebook fallback to English when language-specific versions are unavailable.
  * Language selector now validates input against available languages with error messaging.

* **New Features**
  * Custom directory paths are now normalized and validated in settings.

* **Documentation**
  * Added multilingual error messages for invalid language selection across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->