### PR TITLE
fix(data-integrity): Phase D — CLD edge-id collisions (H2) + lost matrix edits (M12)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/cld_interaction_helpers.R
+++ b/MarineSABRES_SES_Shiny/functions/cld_interaction_helpers.R
@@ -330,11 +330,14 @@ generate_cancel_add_node_js <- function(network_id) {
 #'
 #' @param from_id Character. Source node ID.
 #' @param to_id Character. Target node ID.
-#' @param edge_count Integer. Current number of edges (for generating new ID).
+#' @param max_existing_id Numeric. The maximum id currently present in the edge
+#'   table (pass \code{max(c(0, suppressWarnings(as.numeric(rv$edges$id))), na.rm = TRUE)}).
+#'   The new edge receives \code{max_existing_id + 1}, which is guaranteed to be
+#'   unique even when the id sequence is sparse (e.g., after deletes).
 #' @return Data frame with one row of edge data.
-create_new_edge_data <- function(from_id, to_id, edge_count) {
+create_new_edge_data <- function(from_id, to_id, max_existing_id) {
   data.frame(
-    id = edge_count + 1,
+    id = max_existing_id + 1,
     from = from_id,
     to = to_id,
     arrows = "to",

--- a/MarineSABRES_SES_Shiny/modules/cld_visualization_module.R
+++ b/MarineSABRES_SES_Shiny/modules/cld_visualization_module.R
@@ -1200,8 +1200,14 @@ cld_viz_server <- function(id, project_data_reactive, i18n, event_bus = NULL) {
       req(input$edge_added)
       debug_log(sprintf("Edge added: %s -> %s", input$edge_added$from, input$edge_added$to), "CLD VIZ")
 
-      # Add to internal state using helper
-      new_edge <- create_new_edge_data(input$edge_added$from, input$edge_added$to, nrow(rv$edges))
+      # Add to internal state using helper.
+      # Allocate from the maximum existing id (not count) so the new id stays
+      # unique even when the edge set is sparse after deletes.
+      new_edge <- create_new_edge_data(
+        input$edge_added$from,
+        input$edge_added$to,
+        max(c(0, suppressWarnings(as.numeric(rv$edges$id))), na.rm = TRUE)
+      )
       rv$edges <- bind_rows(rv$edges, new_edge)
 
       # Sync to project_data + propagate to isa_data so analyses refresh.
@@ -1455,6 +1461,13 @@ cld_viz_server <- function(id, project_data_reactive, i18n, event_bus = NULL) {
       debug_log(sprintf("Edges deleted: %s", paste(deleted_ids, collapse = ", ")), "CLD VIZ")
 
       rv$edges <- rv$edges %>% filter(!(id %in% deleted_ids))
+      # Reindex edge ids to keep them contiguous (1..n) after deletion.
+      # build_leverage_highlight_data / build_leverage_reset_data use
+      # seq_len(nrow(edges)) for vis.js proxy updates, so sparse ids would
+      # silently mismatch the wrong edges in the network canvas.
+      if (nrow(rv$edges) > 0) {
+        rv$edges$id <- seq_len(nrow(rv$edges))
+      }
 
       # Sync to project_data + propagate to isa_data so analyses refresh.
       isolate({

--- a/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
+++ b/MarineSABRES_SES_Shiny/modules/isa_data_entry_module.R
@@ -39,6 +39,55 @@ isa_data_entry_ui <- function(id, i18n) {
   )
 }
 
+# ── M12: user_edited_matrices persistence helpers ──────────────────────────────
+#
+# Pure (non-reactive) function exported at module-file scope so it is testable
+# without instantiating a Shiny session.
+#
+# Restores user_edited_matrices from a previously-saved project into the
+# shape of the current (post-reconcile) adjacency_matrices.  For each key:
+#   - If saved_ue has the key AND dimnames have common rows/cols, TRUE cells
+#     are projected into the new (possibly larger/smaller) matrix.
+#   - If saved_ue is NULL / empty / missing a key, falls back to all-FALSE
+#     (safe default for old saves that pre-date M12).
+#
+# @param saved_ue   Named list of logical matrices from saved project
+#                   (project$data$isa_data$user_edited_matrices), or NULL.
+# @param adj_matrices Named list of character matrices (adjacency_matrices),
+#                   used to determine the required dims/dimnames for each key.
+# @return Named list of logical matrices aligned to adj_matrices.
+restore_user_edited_matrices <- function(saved_ue, adj_matrices) {
+  result <- list()
+  if (!is.list(adj_matrices) || length(adj_matrices) == 0) return(result)
+
+  for (mk in names(adj_matrices)) {
+    adj <- adj_matrices[[mk]]
+    if (!is.matrix(adj)) {
+      next
+    }
+    nr <- nrow(adj); nc <- ncol(adj)
+    rn <- rownames(adj); cn <- colnames(adj)
+
+    # Default: all-FALSE matrix with correct dims
+    out_ue <- matrix(FALSE, nrow = nr, ncol = nc, dimnames = list(rn, cn))
+
+    # Overlay from saved_ue where dimnames overlap (safe for size changes)
+    if (is.list(saved_ue) && !is.null(saved_ue[[mk]]) &&
+        is.matrix(saved_ue[[mk]]) && is.logical(saved_ue[[mk]])) {
+      s <- saved_ue[[mk]]
+      common_rows <- intersect(rownames(s), rn)
+      common_cols <- intersect(colnames(s), cn)
+      if (length(common_rows) > 0 && length(common_cols) > 0) {
+        out_ue[common_rows, common_cols] <- s[common_rows, common_cols]
+      }
+    }
+
+    result[[mk]] <- out_ue
+  }
+  result
+}
+# ──────────────────────────────────────────────────────────────────────────────
+
 # Module Server ----
 # Standardized signature: (id, project_data_reactive, i18n, event_bus)
 isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = NULL, parent_session = NULL) {
@@ -223,6 +272,8 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
 
       if (!is.null(isa_data$adjacency_matrices)) {
         pd$data$isa_data$adjacency_matrices <- isa_data$adjacency_matrices
+        # M12: persist user-edited-cell flags so they survive a save/reload cycle
+        pd$data$isa_data$user_edited_matrices <- isa_data$user_edited_matrices
       }
       if (!is.null(isa_data$loop_connections)) {
         pd$data$isa_data$loop_connections <- isa_data$loop_connections
@@ -291,7 +342,16 @@ isa_data_entry_server <- function(id, project_data_reactive, i18n, event_bus = N
       }
       for (p in names(rec$panel_ids)) isa_data[[p]] <- rec$panel_ids[[p]]
       isa_data$adjacency_matrices <- rec$adjacency_matrices
-      isa_data$user_edited_matrices[names(rec$user_edited_matrices)] <- rec$user_edited_matrices
+      # M12: restore saved user-edited flags (fall back to all-FALSE for old saves).
+      # restore_user_edited_matrices() aligns dims to the post-reconcile adjacency_matrices,
+      # then overlays saved TRUE cells by dimname intersection — safe for size changes.
+      # rec$user_edited_matrices only holds all-FALSE entries for fell-back matrices;
+      # the SAVED flags (from project$data$isa_data$user_edited_matrices, written by the
+      # fixed sync_to_project_data) are the authoritative source for user edits.
+      isa_data$user_edited_matrices <- restore_user_edited_matrices(
+        saved_ue     = saved_isa$user_edited_matrices,
+        adj_matrices = isa_data$adjacency_matrices
+      )
       any_repaired      <- rec$repaired
       any_rows_in       <- rec$any_rows_in
       any_panel_ids_out <- rec$any_panel_ids_out

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-cld-edge-id.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-cld-edge-id.R
@@ -1,0 +1,83 @@
+# test-cld-edge-id.R
+# Unit tests for edge ID allocation in create_new_edge_data()
+# (functions/cld_interaction_helpers.R)
+#
+# Regression for H2: before the fix, new edge id = nrow(edges)+1, which
+# collides after any delete (ids {1,3} -> nrow=2 -> next id=3, collision).
+
+library(testthat)
+
+source_for_test("functions/cld_interaction_helpers.R")
+
+# ---------------------------------------------------------------------------
+# Collision tests
+# ---------------------------------------------------------------------------
+
+test_that("new edge id is greater than every existing id (no collision after delete)", {
+  skip_if_not(exists("create_new_edge_data", mode = "function"))
+
+  # Simulate: edges with ids 1,2,3 then 2 deleted -> existing ids {1,3}, count=2.
+  # The OLD code produced id = nrow+1 = 3, which collides with existing id 3.
+  # The NEW code uses max_existing_id = max(c(0, 1, 3)) = 3, so new id = 4.
+  existing_ids <- c(1L, 3L)
+  max_id <- max(c(0L, suppressWarnings(as.numeric(existing_ids))), na.rm = TRUE)
+  e <- create_new_edge_data("A", "B", max_id)
+
+  expect_false(e$id %in% existing_ids,
+    info = "New edge id must not collide with any existing id")
+  expect_equal(e$id, 4L,
+    info = "New id must be max(existing)+1 = 3+1 = 4")
+})
+
+test_that("new edge id is unique when existing ids are non-contiguous after multiple deletes", {
+  skip_if_not(exists("create_new_edge_data", mode = "function"))
+
+  # Worst case: original 1..10, then 2,4,6,8 deleted -> {1,3,5,7,9,10}
+  # nrow=6 -> old code gives id=7, collision with 7.
+  existing_ids <- c(1L, 3L, 5L, 7L, 9L, 10L)
+  max_id <- max(c(0L, suppressWarnings(as.numeric(existing_ids))), na.rm = TRUE)
+  e <- create_new_edge_data("X", "Y", max_id)
+
+  expect_false(e$id %in% existing_ids,
+    info = "New id must not collide with any existing id in {1,3,5,7,9,10}")
+  expect_equal(e$id, 11L,
+    info = "New id must be max(1,3,5,7,9,10)+1 = 11")
+})
+
+test_that("new edge id = 1 when edge table is empty", {
+  skip_if_not(exists("create_new_edge_data", mode = "function"))
+
+  max_id <- max(c(0L, suppressWarnings(as.numeric(integer(0)))), na.rm = TRUE)
+  e <- create_new_edge_data("A", "B", max_id)
+
+  expect_equal(e$id, 1L,
+    info = "First edge in empty table must get id = 1")
+})
+
+# ---------------------------------------------------------------------------
+# Well-formed row tests
+# ---------------------------------------------------------------------------
+
+test_that("create_new_edge_data returns a well-formed edge row", {
+  skip_if_not(exists("create_new_edge_data", mode = "function"))
+
+  e <- create_new_edge_data("A", "B", 0L)
+
+  expect_equal(nrow(e), 1L)
+  expect_equal(e$from, "A")
+  expect_equal(e$to, "B")
+  expect_true("polarity" %in% names(e),
+    info = "Edge row must include 'polarity' column")
+  expect_true("id" %in% names(e),
+    info = "Edge row must include 'id' column")
+  expect_true(is.numeric(e$id) || is.integer(e$id),
+    info = "Edge id must be numeric")
+})
+
+test_that("create_new_edge_data polarity defaults to '+'", {
+  skip_if_not(exists("create_new_edge_data", mode = "function"))
+
+  e <- create_new_edge_data("A", "B", 5L)
+
+  expect_equal(e$polarity, "+")
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-user-edited-matrices-persist.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-user-edited-matrices-persist.R
@@ -1,0 +1,164 @@
+# tests/testthat/test-user-edited-matrices-persist.R
+#
+# M12: user_edited_matrices must survive a save → reload round-trip.
+#
+# APPROACH: Static + seam round-trip (NOT testServer).
+#   Rationale: isa_data_entry_module.R is a 1600-line reactive module; testServer
+#   of the full server carries segfault risk per project conventions (bare Rscript -e
+#   with heavy sources). Instead:
+#   1. Static grep: assert sync_to_project_data() writes user_edited_matrices to pd.
+#   2. Seam round-trip: source the pure helper restore_user_edited_matrices()
+#      (extracted from apply_saved_isa in isa_data_entry_module.R) and verify that
+#      a TRUE cell in a saved user_edited_matrices survives the restore step.
+#
+# LIMITATION: the static test proves the assignment is textually present; a live
+#   testServer() test would confirm runtime behavior.  The seam test proves the
+#   restore logic is correct for the happy path and the old-save fallback path.
+
+library(testthat)
+library(shiny)
+
+# Source the pure helper (extracted in the M12 fix).
+source_for_test("functions/matrix_from_linked.R")
+
+# ── 1. Static: sync_to_project_data() writes user_edited_matrices ────────────
+
+test_that("sync_to_project_data writes user_edited_matrices to project data", {
+  expect_context_key_in_file(
+    "modules/isa_data_entry_module.R",
+    "pd$data$isa_data$user_edited_matrices <- isa_data$user_edited_matrices",
+    info = paste(
+      "sync_to_project_data() must persist user_edited_matrices so that",
+      "user-tuned matrix cells survive a save/reload cycle (M12)."
+    )
+  )
+})
+
+# ── 2. Seam: restore_user_edited_matrices() round-trip ───────────────────────
+#
+# restore_user_edited_matrices(saved_ue, adj_matrices) is a pure function
+# extracted from apply_saved_isa.  It takes:
+#   saved_ue     — list of logical matrices (from saved project$data$isa_data$user_edited_matrices)
+#   adj_matrices — the adjacency matrices that were just loaded/reconciled
+# and returns a list of logical matrices aligned to adj_matrices, with:
+#   - TRUE cells preserved from saved_ue wherever dimnames match
+#   - all-FALSE default for keys/cells not present in saved_ue (old-save safety)
+
+source_for_test("modules/isa_data_entry_module.R")
+
+test_that("restore_user_edited_matrices() is exported by isa_data_entry_module.R", {
+  skip_if_not(
+    exists("restore_user_edited_matrices", mode = "function"),
+    "restore_user_edited_matrices not available — M12 fix may not be sourced yet (expected failure)"
+  )
+  expect_true(is.function(restore_user_edited_matrices))
+})
+
+test_that("TRUE user-edited cell survives save→reload round-trip via restore_user_edited_matrices", {
+  skip_if_not(
+    exists("restore_user_edited_matrices", mode = "function"),
+    "restore_user_edited_matrices not available — expected failure before M12 fix"
+  )
+
+  # Simulate the saved adjacency matrix for es_gb (after project save)
+  adj <- matrix(
+    c("+HighMedium:High", "", "", "+MediumMedium:Medium"),
+    nrow = 2, ncol = 2,
+    dimnames = list(c("ES001", "ES002"), c("GB001", "GB002"))
+  )
+
+  # Simulate the saved user_edited_matrices (as persisted by the fixed sync_to_project_data)
+  saved_ue <- list(
+    es_gb = matrix(
+      c(TRUE, FALSE, FALSE, FALSE),
+      nrow = 2, ncol = 2,
+      dimnames = list(c("ES001", "ES002"), c("GB001", "GB002"))
+    )
+  )
+
+  adj_matrices <- list(es_gb = adj)
+
+  # Run the restore helper
+  restored <- restore_user_edited_matrices(saved_ue, adj_matrices)
+
+  # The TRUE at [ES001, GB001] must survive
+  expect_true(
+    restored$es_gb["ES001", "GB001"],
+    label = "User-edited TRUE cell [ES001,GB001] must be preserved after restore"
+  )
+  # The FALSE cells must remain FALSE
+  expect_false(restored$es_gb["ES001", "GB002"])
+  expect_false(restored$es_gb["ES002", "GB001"])
+  expect_false(restored$es_gb["ES002", "GB002"])
+})
+
+test_that("old-save fallback: restore_user_edited_matrices returns all-FALSE when saved_ue is NULL", {
+  skip_if_not(
+    exists("restore_user_edited_matrices", mode = "function"),
+    "restore_user_edited_matrices not available — expected failure before M12 fix"
+  )
+
+  adj <- matrix("", nrow = 2, ncol = 2,
+                dimnames = list(c("ES001", "ES002"), c("GB001", "GB002")))
+  adj_matrices <- list(es_gb = adj)
+
+  # Old save: no user_edited_matrices saved
+  restored <- restore_user_edited_matrices(NULL, adj_matrices)
+
+  # Must return all-FALSE for es_gb (not an error)
+  expect_true(is.list(restored))
+  expect_true("es_gb" %in% names(restored))
+  expect_false(any(restored$es_gb))
+})
+
+test_that("old-save fallback: restore_user_edited_matrices returns all-FALSE when saved_ue is empty list", {
+  skip_if_not(
+    exists("restore_user_edited_matrices", mode = "function"),
+    "restore_user_edited_matrices not available — expected failure before M12 fix"
+  )
+
+  adj <- matrix("", nrow = 1, ncol = 1,
+                dimnames = list("D001", "A001"))
+  adj_matrices <- list(d_a = adj)
+
+  restored <- restore_user_edited_matrices(list(), adj_matrices)
+
+  expect_true(is.list(restored))
+  expect_true("d_a" %in% names(restored))
+  expect_false(any(restored$d_a))
+})
+
+test_that("restore_user_edited_matrices handles dimension mismatch gracefully (falls back to all-FALSE)", {
+  skip_if_not(
+    exists("restore_user_edited_matrices", mode = "function"),
+    "restore_user_edited_matrices not available — expected failure before M12 fix"
+  )
+
+  # Saved matrix has 2 rows; current adjacency has 3 rows (element was added)
+  saved_ue <- list(
+    a_p = matrix(c(TRUE, FALSE), nrow = 2, ncol = 1,
+                 dimnames = list(c("A001", "A002"), "P001"))
+  )
+  # After reconcile, A003 was added
+  adj <- matrix("", nrow = 3, ncol = 1,
+                dimnames = list(c("A001", "A002", "A003"), "P001"))
+  adj_matrices <- list(a_p = adj)
+
+  # restore must not error; should preserve TRUE for A001 but all-FALSE for A003
+  restored <- restore_user_edited_matrices(saved_ue, adj_matrices)
+  expect_true(restored$a_p["A001", "P001"])
+  expect_false(restored$a_p["A003", "P001"])
+})
+
+# ── 3. Static: apply_saved_isa overlays saved user_edited_matrices ────────────
+
+test_that("apply_saved_isa source overlays saved_isa$user_edited_matrices (not just recover defaults)", {
+  expect_context_key_in_file(
+    "modules/isa_data_entry_module.R",
+    "restore_user_edited_matrices",
+    info = paste(
+      "apply_saved_isa() must call restore_user_edited_matrices() so that",
+      "the SAVED user_edited_matrices (not just recover defaults) are restored."
+    )
+  )
+})


### PR DESCRIPTION
Phase D of the fix plan — **data integrity**. Each task TDD + independently reviewed (spec + quality); the reviews adversarially traced the reactive/data flows for new-bug risk.

| # | Fix | Commit |
|---|---|---|
| **D1 (H2)** | CLD new-edge ids allocated from `max(existing ids)+1` (was `nrow+1` → collided after a delete, so edit/delete hit the WRONG edge). Helper param renamed `edge_count`→`max_existing_id`; delete observer reindexes so the leverage-highlight `seq_len` ids stay consistent. **Review verified** the reindex does NOT create an R↔vis.js-canvas id mismatch (vis.js removes the edge before R fires; the delete flow triggers a full re-render from the reindexed edges). | `3abf2d0` |
| **D2 (M12)** | `user_edited_matrices` (the manual-cell-edit flags) now persisted in `sync_to_project_data` and restored on load via a new pure `restore_user_edited_matrices()` — so manually-tuned matrix values are no longer silently overwritten by LinkedX defaults on the next save. **Review verified** the restore is dimname-keyed (not positional), aligns with the adjacency matrices (no `assert_matrices_aligned` violation), and degrades safely on old saves / id-reconcile. | `c79ed71` |

**Verification:** cld-edge-id 12, user-edited-persist 17; regressions clean — cld-viz 8, isa-data-entry 8, matrix-from-linked 29, cld-to-isa-sync 57; i18n audit `missing=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User edits to connection data now persist across save and reload cycles.

* **Bug Fixes**
  * Fixed edge ID conflicts in network visualization that could occur after deleting edges.

* **Tests**
  * Added test coverage for edge management and data persistence features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->