### PR TITLE
fix: autosave reliability (M3/L5) + uniform download guards (M8/L6/L7)

### DIFF
--- a/MarineSABRES_SES_Shiny/modules/analysis_loops.R
+++ b/MarineSABRES_SES_Shiny/modules/analysis_loops.R
@@ -933,36 +933,7 @@ analysis_loops_server <- function(id, project_data_reactive, i18n, event_bus = N
         req(loop_data$loops)
 
         tryCatch({
-          loops <- loop_data$loops
-          reinforcing <- sum(loops$Type == "Reinforcing")
-          balancing <- sum(loops$Type == "Balancing")
-
-          doc <- officer::read_docx()
-          doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_title"), style = "heading 1")
-          doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_generated"), Sys.Date()))
-          doc <- officer::body_add_par(doc, "")
-
-          # Summary section
-          doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_summary"), style = "heading 2")
-          doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_total_loops"), nrow(loops)))
-          doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_reinforcing_loops"), reinforcing))
-          doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_balancing_loops"), balancing))
-          doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_avg_length"), round(mean(as.numeric(loops$Length), na.rm = TRUE), 1)))
-          doc <- officer::body_add_par(doc, "")
-
-          # All loops table
-          doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_detected_loops"), style = "heading 2")
-          ft <- flextable::flextable(loops)
-          ft <- flextable::autofit(ft)
-          doc <- flextable::body_add_flextable(doc, ft)
-          doc <- officer::body_add_par(doc, "")
-
-          # Methodology note
-          doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_methodology"), style = "heading 2")
-          doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_methodology_text"))
-
-          print(doc, target = file)
-
+          build_loop_report_docx(loops = loop_data$loops, i18n = i18n, target = file)
         }, error = function(e) {
           debug_log(paste("Loop report generation failed:", e$message), "EXPORT")
           # M8: do NOT silently write CSV bytes to a .docx file — Word refuses
@@ -1139,4 +1110,60 @@ analysis_loops_server <- function(id, project_data_reactive, i18n, event_bus = N
 
     return(reactive({ loop_data }))
   })
+}
+
+# =============================================================================
+# PURE HELPER — testable outside a Shiny session
+# =============================================================================
+
+#' Build Loop Analysis Report Document
+#'
+#' Constructs an officer Word document from a loop data frame and writes it
+#' to \code{target} via \code{writer}. Raises on any failure — the caller's
+#' \code{tryCatch} is responsible for user notification.
+#'
+#' @param loops   data.frame with columns ID, Type, Length, Members
+#' @param i18n    i18n object (or list with a \code{t()} function)
+#' @param target  File path to write the .docx to
+#' @param writer  Function(doc, target) — defaults to \code{print(doc, target=target)}.
+#'   Override in tests to inject forced failures without touching the filesystem.
+#'
+#' @return Invisibly returns the path written to.
+#' @export
+build_loop_report_docx <- function(
+    loops,
+    i18n,
+    target,
+    writer = function(doc, target) print(doc, target = target)
+) {
+  reinforcing <- sum(loops$Type == "Reinforcing")
+  balancing   <- sum(loops$Type == "Balancing")
+
+  doc <- officer::read_docx()
+  doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_title"), style = "heading 1")
+  doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_generated"), Sys.Date()))
+  doc <- officer::body_add_par(doc, "")
+
+  # Summary section
+  doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_summary"), style = "heading 2")
+  doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_total_loops"), nrow(loops)))
+  doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_reinforcing_loops"), reinforcing))
+  doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_balancing_loops"), balancing))
+  doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_avg_length"),
+    round(mean(as.numeric(loops$Length), na.rm = TRUE), 1)))
+  doc <- officer::body_add_par(doc, "")
+
+  # All loops table
+  doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_detected_loops"), style = "heading 2")
+  ft  <- flextable::flextable(loops)
+  ft  <- flextable::autofit(ft)
+  doc <- flextable::body_add_flextable(doc, ft)
+  doc <- officer::body_add_par(doc, "")
+
+  # Methodology note
+  doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_methodology"), style = "heading 2")
+  doc <- officer::body_add_par(doc, i18n$t("modules.analysis.loops.report_methodology_text"))
+
+  writer(doc, target)
+  invisible(target)
 }

--- a/MarineSABRES_SES_Shiny/modules/analysis_loops.R
+++ b/MarineSABRES_SES_Shiny/modules/analysis_loops.R
@@ -947,7 +947,7 @@ analysis_loops_server <- function(id, project_data_reactive, i18n, event_bus = N
           doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_total_loops"), nrow(loops)))
           doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_reinforcing_loops"), reinforcing))
           doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_balancing_loops"), balancing))
-          doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_avg_length"), round(mean(loops$Length), 1)))
+          doc <- officer::body_add_par(doc, paste(i18n$t("modules.analysis.loops.report_avg_length"), round(mean(as.numeric(loops$Length), na.rm = TRUE), 1)))
           doc <- officer::body_add_par(doc, "")
 
           # All loops table
@@ -964,9 +964,17 @@ analysis_loops_server <- function(id, project_data_reactive, i18n, event_bus = N
           print(doc, target = file)
 
         }, error = function(e) {
-          # Fallback: write a simple CSV if officer fails
           debug_log(paste("Loop report generation failed:", e$message), "EXPORT")
-          utils::write.csv(loop_data$loops, file, row.names = FALSE)
+          # M8: do NOT silently write CSV bytes to a .docx file — Word refuses
+          # to open the result and the user is left guessing.
+          # Surface the error and let the user try a different export.
+          showNotification(
+            paste0(i18n$t("common.messages.word_export_failed") %||%
+                     "Could not generate Word document.",
+                   " (", e$message, ")"),
+            type = "error", duration = NULL
+          )
+          stop(e)  # propagates to downloadHandler, which cleans up the temp file
         })
       }
     )

--- a/MarineSABRES_SES_Shiny/modules/auto_save_module.R
+++ b/MarineSABRES_SES_Shiny/modules/auto_save_module.R
@@ -860,17 +860,18 @@ auto_save_server <- function(id, project_data_reactive, i18n,
 
             # If enough time has passed, trigger save
             if (time_since_change >= current_debounce) {
-              # Reset pending flag (stops polling until next change event)
-              debounce_state$pending_save <- FALSE
-              debounce_state$last_change_time <- NULL
-
               # Skip this tick if a previous save is still running (I1a).
-              # pending_save stays TRUE — next 2s tick will retry once the flag clears.
+              # Leave pending_save and last_change_time intact so the next
+              # 2s tick will retry once save_in_progress clears.
               if (isTRUE(auto_save$save_in_progress)) {
                 debug_log("Save already in progress, will retry on next tick", "AUTO-SAVE ADAPTIVE")
-                # Do NOT clear pending_save or last_change_time — let the next tick re-evaluate
                 return()
               }
+
+              # Reset pending flag now that we are committed to proceeding
+              # (stops polling until the next change event sets it again).
+              debounce_state$pending_save <- FALSE
+              debounce_state$last_change_time <- NULL
 
               # Only save if enabled and not in recovery mode
               if (auto_save$is_enabled && !auto_save$recovery_pending) {
@@ -905,25 +906,40 @@ auto_save_server <- function(id, project_data_reactive, i18n,
     }
 
     # Fallback: Mark data as dirty when project_data changes directly (for compatibility)
-    # This handles cases where event bus might not be available or data changes outside ISA
+    # This handles cases where event bus might not be available or data changes outside ISA.
+    #
+    # Two distinct responsibilities that must be kept separate:
+    #   1. FIRST-LOAD immediate save (when last_data_hash is NULL): always run,
+    #      even when event_bus is present, because the event-bus path does NOT
+    #      issue a first-load save.
+    #   2. SUBSEQUENT-CHANGE dirty marking (when last_data_hash is set): only
+    #      run when event_bus is absent.  When event_bus is present it owns
+    #      change detection via on_isa_change(); hashing every project_data
+    #      mutation here would be redundant, expensive CPU work on every
+    #      reactive flush — harmful on single-process multi-user deployments.
     observeEvent(project_data_reactive(), {
       data <- project_data_reactive()
+      if (is.null(data)) return()
 
-      # Calculate hash of current data
-      if (!is.null(data)) {
-        current_hash <- digest::digest(data)
-
-        # Only mark dirty if hash has changed
-        if (is.null(auto_save$last_data_hash) || current_hash != auto_save$last_data_hash) {
-          auto_save$data_dirty <- TRUE
-
-          # Immediate save on first data load (when last_data_hash is NULL)
-          # This ensures newly loaded/imported data is saved immediately
-          if (is.null(auto_save$last_data_hash) && auto_save$is_enabled && !auto_save$recovery_pending) {
-            debug_log("First data detected - performing immediate save", "AUTO-SAVE")
-            perform_auto_save()
-          }
+      # --- First load: perform an immediate save regardless of event_bus ---
+      if (is.null(auto_save$last_data_hash)) {
+        auto_save$data_dirty <- TRUE
+        if (auto_save$is_enabled && !auto_save$recovery_pending) {
+          debug_log("First data detected - performing immediate save", "AUTO-SAVE")
+          perform_auto_save()
         }
+        return()
+      }
+
+      # --- Subsequent changes: skip when event_bus is present ---
+      # The event-bus path (on_isa_change observer + debounce timer) owns
+      # change detection when event_bus is available; avoid redundant hashing.
+      if (!is.null(event_bus)) return()
+
+      # No event_bus: use hash-based dirty marking as the sole save trigger
+      current_hash <- digest::digest(data)
+      if (current_hash != auto_save$last_data_hash) {
+        auto_save$data_dirty <- TRUE
       }
     })
 

--- a/MarineSABRES_SES_Shiny/modules/auto_save_module.R
+++ b/MarineSABRES_SES_Shiny/modules/auto_save_module.R
@@ -928,6 +928,7 @@ auto_save_server <- function(id, project_data_reactive, i18n,
           debug_log("First data detected - performing immediate save", "AUTO-SAVE")
           perform_auto_save()
         }
+        # Note: if perform_auto_save() returned early (malformed data / not yet enabled), last_data_hash stays NULL and a subsequent project_data change re-enters this branch and retries — intentional low-cost retry inherited from the original implementation.
         return()
       }
 

--- a/MarineSABRES_SES_Shiny/modules/prepare_report_module.R
+++ b/MarineSABRES_SES_Shiny/modules/prepare_report_module.R
@@ -591,7 +591,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".html")
       },
       content = function(file) {
-        req(!is.null(rv$html_report_path) && file.exists(rv$html_report_path))
+        req(report_path_is_servable(rv$html_report_path))
         file.copy(rv$html_report_path, file)
       }
     )
@@ -602,7 +602,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".html")
       },
       content = function(file) {
-        req(!is.null(rv$html_report_path) && file.exists(rv$html_report_path))
+        req(report_path_is_servable(rv$html_report_path))
         file.copy(rv$html_report_path, file)
       }
     )
@@ -613,7 +613,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".pdf")
       },
       content = function(file) {
-        req(!is.null(rv$pdf_report_path) && file.exists(rv$pdf_report_path))
+        req(report_path_is_servable(rv$pdf_report_path))
         file.copy(rv$pdf_report_path, file)
       }
     )
@@ -624,7 +624,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".docx")
       },
       content = function(file) {
-        req(!is.null(rv$word_report_path) && file.exists(rv$word_report_path))
+        req(report_path_is_servable(rv$word_report_path))
         file.copy(rv$word_report_path, file)
       }
     )
@@ -635,7 +635,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".pptx")
       },
       content = function(file) {
-        req(!is.null(rv$ppt_report_path) && file.exists(rv$ppt_report_path))
+        req(report_path_is_servable(rv$ppt_report_path))
         file.copy(rv$ppt_report_path, file)
       }
     )
@@ -1265,4 +1265,23 @@ generate_ppt_report <- function(data, title, author, sections, output_file) {
 
   # Save presentation
   print(ppt, target = output_file)
+}
+
+# =============================================================================
+# PURE HELPER — testable outside a Shiny session
+# =============================================================================
+
+#' Check Whether a Report Path Is Safe to Serve
+#'
+#' Returns TRUE only when \code{path} is a non-NULL character scalar that points
+#' to an existing file. All five download handlers guard with
+#' \code{req(report_path_is_servable(rv$<x>_report_path))} so that Shiny
+#' silently aborts (no download, no error modal) when the report has not been
+#' generated yet.
+#'
+#' @param path  A candidate file path (any R object accepted).
+#' @return Logical scalar.
+#' @export
+report_path_is_servable <- function(path) {
+  !is.null(path) && is.character(path) && length(path) == 1L && file.exists(path)
 }

--- a/MarineSABRES_SES_Shiny/modules/prepare_report_module.R
+++ b/MarineSABRES_SES_Shiny/modules/prepare_report_module.R
@@ -591,6 +591,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".html")
       },
       content = function(file) {
+        req(!is.null(rv$html_report_path) && file.exists(rv$html_report_path))
         file.copy(rv$html_report_path, file)
       }
     )
@@ -601,6 +602,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".html")
       },
       content = function(file) {
+        req(!is.null(rv$html_report_path) && file.exists(rv$html_report_path))
         file.copy(rv$html_report_path, file)
       }
     )
@@ -611,6 +613,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".pdf")
       },
       content = function(file) {
+        req(!is.null(rv$pdf_report_path) && file.exists(rv$pdf_report_path))
         file.copy(rv$pdf_report_path, file)
       }
     )
@@ -621,6 +624,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".docx")
       },
       content = function(file) {
+        req(!is.null(rv$word_report_path) && file.exists(rv$word_report_path))
         file.copy(rv$word_report_path, file)
       }
     )
@@ -631,6 +635,7 @@ prepare_report_server <- function(id, project_data_reactive, i18n, parent_sessio
         generate_export_filename(sanitize_filename(input$report_title), ".pptx")
       },
       content = function(file) {
+        req(!is.null(rv$ppt_report_path) && file.exists(rv$ppt_report_path))
         file.copy(rv$ppt_report_path, file)
       }
     )

--- a/MarineSABRES_SES_Shiny/modules/response_module.R
+++ b/MarineSABRES_SES_Shiny/modules/response_module.R
@@ -744,16 +744,12 @@ response_measures_server <- function(id, project_data_reactive, i18n, event_bus 
       },
       content = function(file) {
         tryCatch({
-          wb <- createWorkbook()
-          addWorksheet(wb, "Response_Measures")
-          addWorksheet(wb, "Impact_Matrix")
-          addWorksheet(wb, "Implementation")
-
-          writeData(wb, "Response_Measures", translate_levels_for_display(response_data$measures))
-          writeData(wb, "Impact_Matrix", response_data$impacts)
-          writeData(wb, "Implementation", response_data$milestones)
-
-          saveWorkbook(wb, file, overwrite = TRUE)
+          build_response_excel(
+            measures   = translate_levels_for_display(response_data$measures),
+            impacts    = response_data$impacts,
+            milestones = response_data$milestones,
+            file       = file
+          )
         }, error = function(e) {
           debug_log(paste("Response Excel export failed:", e$message), "EXPORT")
           # L7: do NOT silently write corrupt bytes to a .xlsx file.
@@ -986,4 +982,43 @@ response_validation_server <- function(id, project_data_reactive, i18n, event_bu
   moduleServer(id, function(input, output, session) {
     # Placeholder
   })
+}
+
+# =============================================================================
+# PURE HELPER — testable outside a Shiny session
+# =============================================================================
+
+#' Build Response Excel Workbook
+#'
+#' Constructs an openxlsx workbook with three sheets (Response_Measures,
+#' Impact_Matrix, Implementation) and saves it to \code{file} via \code{saver}.
+#' Raises on any failure — the caller's \code{tryCatch} handles notification.
+#'
+#' @param measures   data.frame of response measures
+#' @param impacts    data.frame of impact matrix
+#' @param milestones data.frame of implementation milestones
+#' @param file       Path to write the .xlsx to
+#' @param saver      Function(wb, file, overwrite) — defaults to
+#'   \code{openxlsx::saveWorkbook}. Override in tests to inject forced failures.
+#'
+#' @return Invisibly returns \code{file}.
+#' @export
+build_response_excel <- function(
+    measures,
+    impacts,
+    milestones,
+    file,
+    saver = openxlsx::saveWorkbook
+) {
+  wb <- openxlsx::createWorkbook()
+  openxlsx::addWorksheet(wb, "Response_Measures")
+  openxlsx::addWorksheet(wb, "Impact_Matrix")
+  openxlsx::addWorksheet(wb, "Implementation")
+
+  openxlsx::writeData(wb, "Response_Measures", measures)
+  openxlsx::writeData(wb, "Impact_Matrix",     impacts)
+  openxlsx::writeData(wb, "Implementation",    milestones)
+
+  saver(wb, file, overwrite = TRUE)
+  invisible(file)
 }

--- a/MarineSABRES_SES_Shiny/modules/response_module.R
+++ b/MarineSABRES_SES_Shiny/modules/response_module.R
@@ -743,16 +743,29 @@ response_measures_server <- function(id, project_data_reactive, i18n, event_bus 
         generate_export_filename("Response_Measures", ".xlsx")
       },
       content = function(file) {
-        wb <- createWorkbook()
-        addWorksheet(wb, "Response_Measures")
-        addWorksheet(wb, "Impact_Matrix")
-        addWorksheet(wb, "Implementation")
+        tryCatch({
+          wb <- createWorkbook()
+          addWorksheet(wb, "Response_Measures")
+          addWorksheet(wb, "Impact_Matrix")
+          addWorksheet(wb, "Implementation")
 
-        writeData(wb, "Response_Measures", translate_levels_for_display(response_data$measures))
-        writeData(wb, "Impact_Matrix", response_data$impacts)
-        writeData(wb, "Implementation", response_data$milestones)
+          writeData(wb, "Response_Measures", translate_levels_for_display(response_data$measures))
+          writeData(wb, "Impact_Matrix", response_data$impacts)
+          writeData(wb, "Implementation", response_data$milestones)
 
-        saveWorkbook(wb, file, overwrite = TRUE)
+          saveWorkbook(wb, file, overwrite = TRUE)
+        }, error = function(e) {
+          debug_log(paste("Response Excel export failed:", e$message), "EXPORT")
+          # L7: do NOT silently write corrupt bytes to a .xlsx file.
+          # Surface the error so the user knows the download failed.
+          showNotification(
+            paste0(i18n$t("common.messages.excel_export_failed") %||%
+                     "Could not generate Excel file.",
+                   " (", e$message, ")"),
+            type = "error", duration = NULL
+          )
+          stop(e)  # propagates to downloadHandler so it does NOT serve a misleading/partial file
+        })
       }
     )
 

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-auto-save-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-auto-save-module.R
@@ -1386,3 +1386,203 @@ test_that("concurrent writes to different session dirs don't interfere", {
     expect_equal(loaded$value, r$expected_value)
   }
 })
+
+# ============================================================================
+# TESTSERVER BEHAVIOR TESTS (M3 + L5 fixes)
+#
+# These tests drive the real auto_save_server via testServer() and assert
+# observable state after reactive flushes.  They require the full module to
+# be loaded (done via global.R in helper-00-load-functions.R) plus a few
+# lightweight stubs for items that only live in the full app context.
+# ============================================================================
+
+# -- Shared helper: build minimal dependencies needed by auto_save_server ----
+.autosave_test_deps <- function() {
+  # APP_VERSION may not be set if global.R load failed; provide a fallback.
+  if (!exists("APP_VERSION", envir = .GlobalEnv)) {
+    assign("APP_VERSION", "test", envir = .GlobalEnv)
+  }
+
+  # Minimal i18n that returns the key verbatim
+  i18n <- list(
+    t = function(key, ...) key,
+    get_translation_language = function() "en"
+  )
+
+  # Minimal event bus matching the real event_bus_setup.R API
+  eb <- reactiveValues(isa_change_counter = 0L)
+  eb$on_isa_change <- reactive(eb$isa_change_counter)
+
+  list(i18n = i18n, eb = eb)
+}
+
+# ============================================================================
+# M3 — debounce flags must NOT be cleared when save_in_progress is TRUE
+# ============================================================================
+
+test_that("M3: debounce_state$pending_save stays TRUE when save_in_progress", {
+  # Skip if auto_save_server not available (e.g. global.R failed to load)
+  skip_if_not(exists("auto_save_server", envir = .GlobalEnv),
+              "auto_save_server not loaded")
+  skip_if_not(requireNamespace("digest", quietly = TRUE), "digest not available")
+  skip_if_not(requireNamespace("jsonlite", quietly = TRUE), "jsonlite not available")
+
+  # Re-bind from .GlobalEnv in case helper-stubs.R shadowed it
+  auto_save_server <- get("auto_save_server", envir = .GlobalEnv)
+
+  deps <- .autosave_test_deps()
+  i18n <- deps$i18n
+  eb   <- deps$eb
+
+  # Project data with valid ISA structure so perform_auto_save does not abort.
+  # Use shiny::reactiveVal explicitly (helper-stubs.R overrides reactiveVal
+  # with a plain closure that is not reactive — the real shiny version is
+  # needed so observers that depend on project_data_reactive() fire correctly).
+  proj <- list(
+    data     = list(isa_data = list(drivers = data.frame(id = "D1", name = "Test"))),
+    metadata = list()
+  )
+  pdr <- shiny::reactiveVal(proj)
+
+  testServer(auto_save_server,
+             args = list(project_data_reactive = pdr,
+                         i18n = i18n,
+                         event_bus = eb),
+             {
+               session$flushReact()
+
+               # Fire an ISA-change event so the debounce observer marks
+               # pending_save = TRUE and records last_change_time.
+               eb$isa_change_counter <- 1L
+               session$flushReact()
+
+               expect_true(debounce_state$pending_save,
+                           label = "pending_save should be TRUE after a change event")
+
+               # Simulate a concurrent save still running and backdate the
+               # change time so the debounce threshold is already elapsed.
+               auto_save$save_in_progress <- TRUE
+               debounce_state$last_change_time <- Sys.time() - 60   # 60 s in the past
+               session$flushReact()
+
+               # Tick the polling observer by advancing the timer past the
+               # invalidateLater(2000) interval.
+               session$elapse(2001)
+               session$flushReact()
+
+               # BUG (before fix): pending_save was cleared to FALSE by lines
+               # that ran before the save_in_progress guard, so the next poll
+               # would see req(FALSE) and stop — silently losing the change.
+               # CORRECT (after fix): pending_save stays TRUE so the retry
+               # fires on the next tick once save_in_progress clears.
+               expect_true(debounce_state$pending_save,
+                           label = paste(
+                             "pending_save must remain TRUE when save_in_progress=TRUE;",
+                             "got:", debounce_state$pending_save
+                           ))
+             })
+})
+
+# ============================================================================
+# L5 — fallback observer: first-load save preserved; redundant hashing skipped
+# ============================================================================
+
+test_that("L5a: first data load triggers immediate save when event_bus present", {
+  skip_if_not(exists("auto_save_server", envir = .GlobalEnv),
+              "auto_save_server not loaded")
+  skip_if_not(requireNamespace("digest", quietly = TRUE), "digest not available")
+  skip_if_not(requireNamespace("jsonlite", quietly = TRUE), "jsonlite not available")
+
+  auto_save_server <- get("auto_save_server", envir = .GlobalEnv)
+
+  deps <- .autosave_test_deps()
+  i18n <- deps$i18n
+  eb   <- deps$eb
+
+  # Start with NULL so hash is unset (first-load scenario).
+  # Use shiny::reactiveVal explicitly — the stub in helper-stubs.R is a plain
+  # closure that is not reactive, so observeEvent() would never fire on it.
+  pdr <- shiny::reactiveVal(NULL)
+
+  testServer(auto_save_server,
+             args = list(project_data_reactive = pdr,
+                         i18n = i18n,
+                         event_bus = eb),
+             {
+               session$flushReact()
+
+               # Confirm hash is NULL before loading data
+               expect_null(auto_save$last_data_hash,
+                           label = "last_data_hash should be NULL before first load")
+
+               # Simulate first-time data load (e.g. project imported)
+               pdr(list(
+                 data     = list(isa_data = list(drivers = data.frame(id = "D1", name = "Test"))),
+                 metadata = list()
+               ))
+               session$flushReact()
+
+               # An immediate save must have happened:
+               # perform_auto_save() sets last_data_hash after a successful save.
+               expect_false(is.null(auto_save$last_data_hash),
+                            label = paste(
+                              "last_data_hash must be non-NULL after first-load immediate save;",
+                              "got:", auto_save$last_data_hash
+                            ))
+             })
+})
+
+test_that("L5b: subsequent data change does NOT set data_dirty via fallback when event_bus present", {
+  skip_if_not(exists("auto_save_server", envir = .GlobalEnv),
+              "auto_save_server not loaded")
+  skip_if_not(requireNamespace("digest", quietly = TRUE), "digest not available")
+  skip_if_not(requireNamespace("jsonlite", quietly = TRUE), "jsonlite not available")
+
+  auto_save_server <- get("auto_save_server", envir = .GlobalEnv)
+
+  deps <- .autosave_test_deps()
+  i18n <- deps$i18n
+  eb   <- deps$eb
+
+  proj1 <- list(
+    data     = list(isa_data = list(drivers = data.frame(id = "D1", name = "First"))),
+    metadata = list()
+  )
+  # Use shiny::reactiveVal so observeEvent fires correctly — see L5a note.
+  pdr <- shiny::reactiveVal(proj1)
+
+  testServer(auto_save_server,
+             args = list(project_data_reactive = pdr,
+                         i18n = i18n,
+                         event_bus = eb),
+             {
+               session$flushReact()
+
+               # After startup the first-load immediate save sets the hash.
+               expect_false(is.null(auto_save$last_data_hash),
+                            label = "last_data_hash should be set after first load")
+
+               # Reset data_dirty so we can cleanly observe whether the
+               # fallback observer sets it again on a subsequent change.
+               auto_save$data_dirty <- FALSE
+               session$flushReact()
+
+               # Change the project data (different hash)
+               pdr(list(
+                 data     = list(isa_data = list(drivers = data.frame(id = "D2", name = "Second"))),
+                 metadata = list()
+               ))
+               session$flushReact()
+
+               # BUG (before fix): fallback observer always computed digest()
+               # and set data_dirty=TRUE even with event_bus present.
+               # CORRECT (after fix): fallback observer returns early when
+               # event_bus is non-NULL and last_data_hash is already set,
+               # so data_dirty remains FALSE (event-bus path owns this).
+               expect_false(auto_save$data_dirty,
+                            label = paste(
+                              "data_dirty should remain FALSE when event_bus owns change detection;",
+                              "got:", auto_save$data_dirty
+                            ))
+             })
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-auto-save-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-auto-save-module.R
@@ -1462,7 +1462,7 @@ test_that("M3: debounce_state$pending_save stays TRUE when save_in_progress", {
                # Simulate a concurrent save still running and backdate the
                # change time so the debounce threshold is already elapsed.
                auto_save$save_in_progress <- TRUE
-               debounce_state$last_change_time <- Sys.time() - 60   # 60 s in the past
+               debounce_state$last_change_time <- Sys.time() - 60   # 60 s ago ensures the debounce threshold is already elapsed without relying on session$elapse() advancing Sys.time(); this test exercises ONLY the save_in_progress guard, not the threshold logic.
                session$flushReact()
 
                # Tick the polling observer by advancing the timer past the

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-download-handler-hardening.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-download-handler-hardening.R
@@ -1,0 +1,260 @@
+# tests/testthat/test-download-handler-hardening.R
+# TDD tests for three download-handler hardening fixes:
+#   F1 (M8) – analysis_loops.R download_loop_report: CSV fallback → canonical error pattern
+#   F2 (L6) – prepare_report_module.R: NULL/missing path guards on 5 download handlers
+#   F3 (L7) – response_module.R download_response_excel: add tryCatch error handling
+#
+# Approach: extract the fragile content body into a small pure helper (where the
+# handler itself can't be easily unit-tested), then test that:
+#   F1/F3: a forced failure surfaces an error (stops) and does NOT write a misleading file
+#   F2:    a NULL/missing path is not served (req() silently aborts; no file is written)
+#
+# All helpers are defined IN the production module — these tests assert their
+# observable effects WITHOUT requiring a full Shiny session.
+
+library(testthat)
+library(shiny)
+
+# ---------------------------------------------------------------------------
+# Shared stub i18n
+# ---------------------------------------------------------------------------
+i18n <- list(t = function(key) key)
+
+# ===========================================================================
+# F1 – analysis_loops.R: loop report error handler must NOT write a CSV fallback
+# ===========================================================================
+
+test_that("F1: loop report content helper stops on officer failure and writes no file [FAILING before fix]", {
+  # The pre-fix code had a CSV fallback that wrote bytes into the .docx file.
+  # After the fix the error handler must: call stop(e) so NO valid file is written.
+  #
+  # We test the extracted helper build_loop_report_doc() which the handler now
+  # delegates to. If the helper doesn't exist yet, the test fails (as required
+  # in TDD) — we detect the pre-fix CSV fallback by reading module source
+  # directly.
+
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "analysis_loops.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/analysis_loops.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  # After the fix this pattern must NOT exist:
+  expect_false(
+    grepl("write\\.csv.*loop_data\\$loops.*file", code_text),
+    info = "download_loop_report content handler must not write a CSV fallback into the .docx path"
+  )
+})
+
+test_that("F1: loop report mean() uses as.numeric() + na.rm=TRUE guard [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "analysis_loops.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/analysis_loops.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  # After the fix the mean call must use as.numeric() and na.rm = TRUE
+  expect_true(
+    grepl("mean\\(as\\.numeric\\(loops\\$Length\\)", code_text),
+    info = "mean(loops$Length) must be guarded with as.numeric() to handle non-numeric Length"
+  )
+  expect_true(
+    grepl("na\\.rm\\s*=\\s*TRUE", code_text),
+    info = "mean() call in loop report must include na.rm = TRUE"
+  )
+})
+
+test_that("F1: loop report error handler calls stop(e) to propagate failure [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "analysis_loops.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/analysis_loops.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  # After the fix the error handler must call stop(e) — not write a csv
+  expect_true(
+    grepl("stop\\(e\\)", code_text),
+    info = "download_loop_report error handler must call stop(e) to propagate the error"
+  )
+})
+
+# ===========================================================================
+# F2 – prepare_report_module.R: each download handler guards against NULL/missing path
+# ===========================================================================
+
+test_that("F2: download_html handler guards against NULL rv$html_report_path [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/prepare_report_module.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  # After fix: req(!is.null(rv$html_report_path) && file.exists(rv$html_report_path))
+  # must appear in the download_html handler
+  expect_true(
+    grepl("req\\(!is\\.null\\(rv\\$html_report_path\\)", code_text),
+    info = "download_html must guard: req(!is.null(rv$html_report_path) && file.exists(...))"
+  )
+})
+
+test_that("F2: download_pdf handler guards against NULL rv$pdf_report_path [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/prepare_report_module.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  expect_true(
+    grepl("req\\(!is\\.null\\(rv\\$pdf_report_path\\)", code_text),
+    info = "download_pdf must guard: req(!is.null(rv$pdf_report_path) && file.exists(...))"
+  )
+})
+
+test_that("F2: download_word handler guards against NULL rv$word_report_path [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/prepare_report_module.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  expect_true(
+    grepl("req\\(!is\\.null\\(rv\\$word_report_path\\)", code_text),
+    info = "download_word must guard: req(!is.null(rv$word_report_path) && file.exists(...))"
+  )
+})
+
+test_that("F2: download_ppt handler guards against NULL rv$ppt_report_path [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/prepare_report_module.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  expect_true(
+    grepl("req\\(!is\\.null\\(rv\\$ppt_report_path\\)", code_text),
+    info = "download_ppt must guard: req(!is.null(rv$ppt_report_path) && file.exists(...))"
+  )
+})
+
+test_that("F2: all 4 download handlers use file.exists() guard [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/prepare_report_module.R")
+  }
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  # Count occurrences of file.exists() inside req() calls for report paths
+  path_guards <- lengths(regmatches(code_text,
+    gregexpr("file\\.exists\\(rv\\$[a-z_]+_report_path\\)", code_text)))
+
+  expect_true(
+    path_guards >= 4,
+    info = paste("Expected at least 4 file.exists guards for report paths, found:", path_guards)
+  )
+})
+
+# ===========================================================================
+# F3 – response_module.R: download_response_excel must have tryCatch error handling
+# ===========================================================================
+
+test_that("F3: download_response_excel content body is wrapped in tryCatch [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "response_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/response_module.R")
+  }
+
+  lines <- readLines(module_path)
+
+  # Find the output$download_response_excel <- downloadHandler assignment line
+  # (not the downloadButton(...) call in the UI section which also contains the string)
+  excel_handler_start <- grep("output\\$download_response_excel.*<-.*downloadHandler", lines)
+  expect_true(length(excel_handler_start) > 0, info = "output$download_response_excel handler must exist")
+
+  # Extract ~40 lines after the assignment to inspect the content body
+  start <- excel_handler_start[1]
+  end <- min(start + 40, length(lines))
+  handler_section <- paste(lines[start:end], collapse = "\n")
+
+  expect_true(
+    grepl("tryCatch", handler_section),
+    info = "download_response_excel content body must be wrapped in tryCatch"
+  )
+})
+
+test_that("F3: download_response_excel error handler calls stop(e) [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "response_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/response_module.R")
+  }
+
+  lines <- readLines(module_path)
+
+  excel_handler_start <- grep("output\\$download_response_excel.*<-.*downloadHandler", lines)
+  expect_true(length(excel_handler_start) > 0)
+
+  start <- excel_handler_start[1]
+  end <- min(start + 40, length(lines))
+  handler_section <- paste(lines[start:end], collapse = "\n")
+
+  expect_true(
+    grepl("stop\\(e\\)", handler_section),
+    info = "download_response_excel error handler must call stop(e) to propagate failure"
+  )
+})
+
+test_that("F3: download_response_excel error handler uses showNotification [FAILING before fix]", {
+  module_path <- file.path(dirname(dirname(getwd())), "modules", "response_module.R")
+  if (!file.exists(module_path)) {
+    module_path <- testthat::test_path("../../modules/response_module.R")
+  }
+
+  lines <- readLines(module_path)
+
+  excel_handler_start <- grep("output\\$download_response_excel.*<-.*downloadHandler", lines)
+  expect_true(length(excel_handler_start) > 0)
+
+  start <- excel_handler_start[1]
+  end <- min(start + 40, length(lines))
+  handler_section <- paste(lines[start:end], collapse = "\n")
+
+  expect_true(
+    grepl("showNotification", handler_section),
+    info = "download_response_excel error handler must call showNotification"
+  )
+})
+
+test_that("F3: excel_export_failed i18n key exists in messages.json for all 9 languages", {
+  messages_path <- file.path(dirname(dirname(getwd())), "translations", "common", "messages.json")
+  if (!file.exists(messages_path)) {
+    messages_path <- testthat::test_path("../../translations/common/messages.json")
+  }
+
+  skip_if_not(file.exists(messages_path), "messages.json not found")
+
+  msgs <- jsonlite::fromJSON(messages_path)
+  key <- "common.messages.excel_export_failed"
+
+  expect_true(
+    key %in% names(msgs$translation),
+    info = paste0("Key '", key, "' must exist in translations/common/messages.json")
+  )
+
+  if (key %in% names(msgs$translation)) {
+    key_translations <- msgs$translation[[key]]
+    required_langs <- c("en", "es", "fr", "de", "lt", "pt", "it", "no", "el")
+    for (lang in required_langs) {
+      expect_true(
+        lang %in% names(key_translations) && nzchar(key_translations[[lang]]),
+        info = paste0("excel_export_failed must be translated for language: ", lang)
+      )
+    }
+  }
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-download-handler-hardening.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-download-handler-hardening.R
@@ -85,7 +85,7 @@ test_that("F1: loop report error handler calls stop(e) to propagate failure [FAI
 # F2 – prepare_report_module.R: each download handler guards against NULL/missing path
 # ===========================================================================
 
-test_that("F2: download_html handler guards against NULL rv$html_report_path [FAILING before fix]", {
+test_that("F2: download_html handler guards against NULL rv$html_report_path [source-grep]", {
   module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
   if (!file.exists(module_path)) {
     module_path <- testthat::test_path("../../modules/prepare_report_module.R")
@@ -93,15 +93,17 @@ test_that("F2: download_html handler guards against NULL rv$html_report_path [FA
 
   code_text <- paste(readLines(module_path), collapse = "\n")
 
-  # After fix: req(!is.null(rv$html_report_path) && file.exists(rv$html_report_path))
-  # must appear in the download_html handler
+  # After fix handlers use report_path_is_servable() — the predicate encapsulates
+  # the !is.null + file.exists guard.  Accept EITHER the refactored or inline form.
+  guarded <- grepl("req\\(report_path_is_servable\\(rv\\$html_report_path\\)", code_text) ||
+             grepl("req\\(!is\\.null\\(rv\\$html_report_path\\)", code_text)
   expect_true(
-    grepl("req\\(!is\\.null\\(rv\\$html_report_path\\)", code_text),
-    info = "download_html must guard: req(!is.null(rv$html_report_path) && file.exists(...))"
+    guarded,
+    info = "download_html must guard the path via report_path_is_servable() or inline req(!is.null + file.exists)"
   )
 })
 
-test_that("F2: download_pdf handler guards against NULL rv$pdf_report_path [FAILING before fix]", {
+test_that("F2: download_pdf handler guards against NULL rv$pdf_report_path [source-grep]", {
   module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
   if (!file.exists(module_path)) {
     module_path <- testthat::test_path("../../modules/prepare_report_module.R")
@@ -109,13 +111,15 @@ test_that("F2: download_pdf handler guards against NULL rv$pdf_report_path [FAIL
 
   code_text <- paste(readLines(module_path), collapse = "\n")
 
+  guarded <- grepl("req\\(report_path_is_servable\\(rv\\$pdf_report_path\\)", code_text) ||
+             grepl("req\\(!is\\.null\\(rv\\$pdf_report_path\\)", code_text)
   expect_true(
-    grepl("req\\(!is\\.null\\(rv\\$pdf_report_path\\)", code_text),
-    info = "download_pdf must guard: req(!is.null(rv$pdf_report_path) && file.exists(...))"
+    guarded,
+    info = "download_pdf must guard the path via report_path_is_servable() or inline req(!is.null + file.exists)"
   )
 })
 
-test_that("F2: download_word handler guards against NULL rv$word_report_path [FAILING before fix]", {
+test_that("F2: download_word handler guards against NULL rv$word_report_path [source-grep]", {
   module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
   if (!file.exists(module_path)) {
     module_path <- testthat::test_path("../../modules/prepare_report_module.R")
@@ -123,13 +127,15 @@ test_that("F2: download_word handler guards against NULL rv$word_report_path [FA
 
   code_text <- paste(readLines(module_path), collapse = "\n")
 
+  guarded <- grepl("req\\(report_path_is_servable\\(rv\\$word_report_path\\)", code_text) ||
+             grepl("req\\(!is\\.null\\(rv\\$word_report_path\\)", code_text)
   expect_true(
-    grepl("req\\(!is\\.null\\(rv\\$word_report_path\\)", code_text),
-    info = "download_word must guard: req(!is.null(rv$word_report_path) && file.exists(...))"
+    guarded,
+    info = "download_word must guard the path via report_path_is_servable() or inline req(!is.null + file.exists)"
   )
 })
 
-test_that("F2: download_ppt handler guards against NULL rv$ppt_report_path [FAILING before fix]", {
+test_that("F2: download_ppt handler guards against NULL rv$ppt_report_path [source-grep]", {
   module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
   if (!file.exists(module_path)) {
     module_path <- testthat::test_path("../../modules/prepare_report_module.R")
@@ -137,13 +143,15 @@ test_that("F2: download_ppt handler guards against NULL rv$ppt_report_path [FAIL
 
   code_text <- paste(readLines(module_path), collapse = "\n")
 
+  guarded <- grepl("req\\(report_path_is_servable\\(rv\\$ppt_report_path\\)", code_text) ||
+             grepl("req\\(!is\\.null\\(rv\\$ppt_report_path\\)", code_text)
   expect_true(
-    grepl("req\\(!is\\.null\\(rv\\$ppt_report_path\\)", code_text),
-    info = "download_ppt must guard: req(!is.null(rv$ppt_report_path) && file.exists(...))"
+    guarded,
+    info = "download_ppt must guard the path via report_path_is_servable() or inline req(!is.null + file.exists)"
   )
 })
 
-test_that("F2: all 4 download handlers use file.exists() guard [FAILING before fix]", {
+test_that("F2: all 4 download handlers have a path guard [source-grep]", {
   module_path <- file.path(dirname(dirname(getwd())), "modules", "prepare_report_module.R")
   if (!file.exists(module_path)) {
     module_path <- testthat::test_path("../../modules/prepare_report_module.R")
@@ -151,13 +159,16 @@ test_that("F2: all 4 download handlers use file.exists() guard [FAILING before f
 
   code_text <- paste(readLines(module_path), collapse = "\n")
 
-  # Count occurrences of file.exists() inside req() calls for report paths
-  path_guards <- lengths(regmatches(code_text,
+  # Accept either the refactored form (report_path_is_servable) or the original inline form
+  refactored_guards <- lengths(regmatches(code_text,
+    gregexpr("req\\(report_path_is_servable\\(rv\\$[a-z_]+_report_path\\)", code_text)))
+  inline_guards <- lengths(regmatches(code_text,
     gregexpr("file\\.exists\\(rv\\$[a-z_]+_report_path\\)", code_text)))
 
+  total_guards <- refactored_guards + inline_guards
   expect_true(
-    path_guards >= 4,
-    info = paste("Expected at least 4 file.exists guards for report paths, found:", path_guards)
+    total_guards >= 4,
+    info = paste("Expected at least 4 path guards (report_path_is_servable or file.exists), found:", total_guards)
   )
 })
 
@@ -230,6 +241,211 @@ test_that("F3: download_response_excel error handler uses showNotification [FAIL
     info = "download_response_excel error handler must call showNotification"
   )
 })
+
+# ===========================================================================
+# BEHAVIORAL TESTS — added to satisfy spec (source-grep alone is insufficient)
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# F1 BEHAVIORAL – build_loop_report_docx() pure helper
+# ---------------------------------------------------------------------------
+
+# Load the module so the helper is available in .GlobalEnv
+source_for_test("modules/analysis_loops.R")
+
+test_that("F1-BEHAVIORAL: build_loop_report_docx() exists as a callable function", {
+  expect_true(
+    exists("build_loop_report_docx", mode = "function"),
+    info = "build_loop_report_docx() must be defined in analysis_loops.R"
+  )
+})
+
+test_that("F1-BEHAVIORAL: forced writer failure propagates as error and leaves no file", {
+  skip_if(!exists("build_loop_report_docx", mode = "function"),
+    "build_loop_report_docx() not yet extracted — helper missing"
+  )
+
+  loops <- data.frame(
+    ID      = "L1",
+    Type    = "Reinforcing",
+    Length  = 3L,
+    Members = "A -> B -> C",
+    stringsAsFactors = FALSE
+  )
+  tmp <- tempfile(fileext = ".docx")
+  on.exit(unlink(tmp))
+
+  # The forced writer stops — the helper must propagate the error
+  expect_error(
+    build_loop_report_docx(
+      loops  = loops,
+      i18n   = i18n,
+      target = tmp,
+      writer = function(doc, target) stop("forced-writer-failure")
+    ),
+    regexp = "forced-writer-failure"
+  )
+
+  # No misleading file must have been written
+  expect_true(
+    !file.exists(tmp) || file.size(tmp) == 0L,
+    info = "A forced failure must not leave a non-empty .docx file on disk"
+  )
+})
+
+test_that("F1-BEHAVIORAL: non-numeric Length handled via as.numeric + na.rm — builds successfully", {
+  skip_if(!exists("build_loop_report_docx", mode = "function"),
+    "build_loop_report_docx() not yet extracted — helper missing"
+  )
+
+  # Length column is character — would blow up mean() without as.numeric()/na.rm guard
+  loops <- data.frame(
+    ID      = c("L1", "L2"),
+    Type    = c("Reinforcing", "Balancing"),
+    Length  = c("3", NA_character_),   # character + NA
+    Members = c("A -> B -> C", "X -> Y"),
+    stringsAsFactors = FALSE
+  )
+  tmp <- tempfile(fileext = ".docx")
+  on.exit(unlink(tmp))
+
+  # Should complete without error and produce a non-empty file
+  build_loop_report_docx(loops = loops, i18n = i18n, target = tmp)
+
+  expect_true(file.exists(tmp) && file.size(tmp) > 0L,
+    info = "Helper must produce a non-empty .docx even when Length is character/NA"
+  )
+})
+
+# ---------------------------------------------------------------------------
+# F2 BEHAVIORAL – report_path_is_servable() predicate
+# ---------------------------------------------------------------------------
+
+# Load the module so the predicate is available
+source_for_test("modules/prepare_report_module.R")
+
+test_that("F2-BEHAVIORAL: report_path_is_servable() exists as a callable function", {
+  expect_true(
+    exists("report_path_is_servable", mode = "function"),
+    info = "report_path_is_servable() must be defined in prepare_report_module.R"
+  )
+})
+
+test_that("F2-BEHAVIORAL: report_path_is_servable() returns FALSE for NULL", {
+  skip_if(!exists("report_path_is_servable", mode = "function"),
+    "report_path_is_servable() not yet extracted — helper missing"
+  )
+  expect_false(report_path_is_servable(NULL))
+})
+
+test_that("F2-BEHAVIORAL: report_path_is_servable() returns FALSE for non-existent path", {
+  skip_if(!exists("report_path_is_servable", mode = "function"),
+    "report_path_is_servable() not yet extracted — helper missing"
+  )
+  expect_false(report_path_is_servable("/no/such/file_xyz_12345.html"))
+})
+
+test_that("F2-BEHAVIORAL: report_path_is_servable() returns TRUE for an existing file", {
+  skip_if(!exists("report_path_is_servable", mode = "function"),
+    "report_path_is_servable() not yet extracted — helper missing"
+  )
+  tmp <- tempfile()
+  on.exit(unlink(tmp))
+  writeLines("hello", tmp)
+  expect_true(report_path_is_servable(tmp))
+})
+
+# ---------------------------------------------------------------------------
+# F3 BEHAVIORAL – build_response_excel() pure helper
+# ---------------------------------------------------------------------------
+
+# Load the module so the helper is available
+source_for_test("modules/response_module.R")
+
+test_that("F3-BEHAVIORAL: build_response_excel() exists as a callable function", {
+  expect_true(
+    exists("build_response_excel", mode = "function"),
+    info = "build_response_excel() must be defined in response_module.R"
+  )
+})
+
+test_that("F3-BEHAVIORAL: forced saver failure propagates as error and leaves no valid xlsx", {
+  skip_if(!exists("build_response_excel", mode = "function"),
+    "build_response_excel() not yet extracted — helper missing"
+  )
+  skip_if_not_installed("openxlsx")
+
+  measures   <- data.frame(Name = "M1", Type = "R", stringsAsFactors = FALSE)
+  impacts    <- data.frame(Element = "E1", Impact = 1L, stringsAsFactors = FALSE)
+  milestones <- data.frame(Task = "T1", Due = "2026-01", stringsAsFactors = FALSE)
+  tmp <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(tmp))
+
+  expect_error(
+    build_response_excel(
+      measures   = measures,
+      impacts    = impacts,
+      milestones = milestones,
+      file       = tmp,
+      saver      = function(wb, file, overwrite) stop("forced-saver-failure")
+    ),
+    regexp = "forced-saver-failure"
+  )
+
+  # No valid (non-empty) xlsx should have been written
+  expect_true(
+    !file.exists(tmp) || file.size(tmp) == 0L,
+    info = "A forced saver failure must not leave a non-empty .xlsx file on disk"
+  )
+})
+
+test_that("F3-BEHAVIORAL: happy path — build_response_excel() produces a non-empty xlsx", {
+  skip_if(!exists("build_response_excel", mode = "function"),
+    "build_response_excel() not yet extracted — helper missing"
+  )
+  skip_if_not_installed("openxlsx")
+
+  measures   <- data.frame(Name = "M1", Type = "R", stringsAsFactors = FALSE)
+  impacts    <- data.frame(Element = "E1", Impact = 1L, stringsAsFactors = FALSE)
+  milestones <- data.frame(Task = "T1", Due = "2026-01", stringsAsFactors = FALSE)
+  tmp <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(tmp))
+
+  build_response_excel(
+    measures   = measures,
+    impacts    = impacts,
+    milestones = milestones,
+    file       = tmp
+  )
+
+  expect_true(file.exists(tmp) && file.size(tmp) > 0L,
+    info = "Happy-path build_response_excel() must produce a non-empty .xlsx"
+  )
+})
+
+# ---------------------------------------------------------------------------
+# F2 SOURCE-GREP: verify download handlers use report_path_is_servable()
+# ---------------------------------------------------------------------------
+
+test_that("F2: all 5 download handlers use report_path_is_servable() [BEHAVIORAL guard]", {
+  module_path <- testthat::test_path("../../modules/prepare_report_module.R")
+  skip_if_not(file.exists(module_path), "prepare_report_module.R not found")
+
+  code_text <- paste(readLines(module_path), collapse = "\n")
+
+  # Count how many download handlers call report_path_is_servable
+  hits <- lengths(regmatches(code_text,
+    gregexpr("req\\(report_path_is_servable\\(", code_text)))
+
+  expect_true(
+    hits >= 4L,
+    info = paste("Expected >= 4 req(report_path_is_servable(...)) calls, found:", hits)
+  )
+})
+
+# ===========================================================================
+# Original source-grep tests (kept as cheap regression guards)
+# ===========================================================================
 
 test_that("F3: excel_export_failed i18n key exists in messages.json for all 9 languages", {
   messages_path <- file.path(dirname(dirname(getwd())), "translations", "common", "messages.json")

--- a/MarineSABRES_SES_Shiny/translations/common/messages.json
+++ b/MarineSABRES_SES_Shiny/translations/common/messages.json
@@ -22,6 +22,17 @@
       "no": "Kunne ikke generere Word-dokument.",
       "el": "Δεν ήταν δυνατή η δημιουργία του εγγράφου Word."
     },
+    "common.messages.excel_export_failed": {
+      "en": "Could not generate Excel file.",
+      "es": "No se pudo generar el archivo Excel.",
+      "fr": "Impossible de générer le fichier Excel.",
+      "de": "Excel-Datei konnte nicht erstellt werden.",
+      "lt": "Nepavyko sukurti Excel failo.",
+      "pt": "Não foi possível gerar o arquivo Excel.",
+      "it": "Impossibile generare il file Excel.",
+      "no": "Kunne ikke generere Excel-fil.",
+      "el": "Δεν ήταν δυνατή η δημιουργία του αρχείου Excel."
+    },
     "common.messages.bookmark_restored_successfully": {
       "en": "Bookmark restored successfully!",
       "es": "¡Marcador restaurado con éxito!",


### PR DESCRIPTION
Phases E + F of the 2026-06-03 code-review fix plan (P1 reliability). Executed via subagent-driven TDD with independent spec + quality review per task.

## Phase E — Autosave reliability (`auto_save_module.R`)
- **M3 (data loss):** The adaptive-debounce poller cleared `pending_save`/`last_change_time` *before* the `save_in_progress` early-return guard, so when a prior save was still running the flags were already cleared — polling stopped (`req(pending_save)` false) and the pending change was silently dropped. Moved the flag-clearing to *after* the guard so a concurrent save retries on the next tick.
- **L5 (redundant work):** The fallback `observeEvent(project_data())` re-hashed the full project on every change even when `event_bus` is present (expensive on the single-process multi-user server). Now skips the redundant `digest()` when `event_bus` drives change detection — **while preserving the first-load immediate save** (the event path doesn't do save-on-load; a blunt early-return would have regressed it).

## Phase F — Uniform download guards (no misleading files on failure)
Adopts the canonical `tryCatch → debug_log + showNotification + stop(e)` pattern already used by `response_module.R::download_priority_report`, so a failed export surfaces an error instead of serving a corrupt/partial file.
- **M8 (`analysis_loops.R`):** error handler no longer writes a CSV into the `.docx` (Word can't open it) — now notifies + `stop(e)`. Also guards `mean(as.numeric(loops$Length), na.rm = TRUE)`.
- **L6 (`prepare_report_module.R`):** all 5 report-serving handlers now `req(report_path_is_servable(path))` (NULL/missing-file guard).
- **L7 (`response_module.R::download_response_excel`):** wrapped in the same tryCatch (was unguarded → corrupt `.xlsx` on failure). New i18n key `common.messages.excel_export_failed` added ×9.

## Testing
- New behavioral tests (pure-helper extraction: `build_loop_report_docx(writer=)`, `build_response_excel(saver=)`, `report_path_is_servable()`): a forced writer/saver failure **raises and leaves no misleading file**; the path predicate returns FALSE for NULL/missing and TRUE for an existing file. Plus source-grep regression guards.
- `test-auto-save-module.R`: M3 retains `pending_save=TRUE` under `save_in_progress`; L5 preserves first-load save and skips re-hashing with `event_bus`.
- **Full suite: 7810 pass / 0 regressions.** The single failure (`test-ml-graph-features.R:359` "reasonably fast") is a **pre-existing flaky timing assertion** unrelated to this branch (documented follow-up to loosen the threshold).
- i18n audit: `missing=0 hardcoded=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Word document export to display error notifications and prevent corrupted file downloads
  * Enhanced Excel export error handling with user-facing notifications
  * Prevented downloading incomplete report files
  * Improved auto-save to prevent losing scheduled saves

* **Translations**
  * Added error message translations for export failures across supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->