### PR TITLE
fix(G3/L24): guardrail — warn on process-global stable-id store in a Shiny session

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/data_structure.R
+++ b/MarineSABRES_SES_Shiny/functions/data_structure.R
@@ -28,11 +28,29 @@ generate_element_id <- function(prefix, n) {
 
 new_stable_id_store <- function() new.env(parent = emptyenv())
 
+# Guardrail (L24): the process-global .stable_id_counters is only safe for unit
+# tests / non-Shiny use. If an allocator is called WITHOUT an explicit session
+# store while a Shiny session is active, warn — sharing global counters across
+# concurrent users causes cross-session ID collisions. Pass new_stable_id_store().
+.warn_if_global_store_in_session <- function(store_was_missing) {
+  if (isTRUE(store_was_missing) && !is.null(shiny::getDefaultReactiveDomain())) {
+    warning(
+      "stable-id allocator called without a session-local `store=` inside a Shiny session; ",
+      "the process-global .stable_id_counters risks cross-session ID collisions. ",
+      "Pass a session store, e.g. store = new_stable_id_store().",
+      call. = FALSE
+    )
+  }
+  invisible(NULL)
+}
+
 reset_stable_id_counter <- function(prefix, store = .stable_id_counters) {
+  .warn_if_global_store_in_session(missing(store))
   assign(prefix, 0L, envir = store); invisible(NULL)
 }
 
 seed_stable_id_counter <- function(prefix, existing_ids, store = .stable_id_counters) {
+  .warn_if_global_store_in_session(missing(store))
   nums <- suppressWarnings(as.integer(sub(paste0("^", prefix), "", existing_ids)))
   nums <- nums[!is.na(nums)]
   assign(prefix, if (length(nums)) max(nums) else 0L, envir = store)
@@ -40,6 +58,7 @@ seed_stable_id_counter <- function(prefix, existing_ids, store = .stable_id_coun
 }
 
 generate_stable_element_id <- function(prefix, store = .stable_id_counters) {
+  .warn_if_global_store_in_session(missing(store))
   cur <- if (exists(prefix, envir = store, inherits = FALSE))
     get(prefix, envir = store) else 0L
   nxt <- cur + 1L
@@ -59,6 +78,7 @@ generate_stable_element_id <- function(prefix, store = .stable_id_counters) {
 #' @param store counter environment (session-local in the module; global default for tests)
 #' @return list(df = repaired data.frame, repaired = logical scalar)
 reconcile_loaded_element_ids <- function(element_df, prefix, store = .stable_id_counters) {
+  .warn_if_global_store_in_session(missing(store))
   if (is.null(element_df) || !nrow(element_df)) return(list(df = element_df, repaired = FALSE))
 
   # Detect the id column case-insensitively. Legacy/fork/JSON-origin/re-saved

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-stable-id-store-guardrail.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-stable-id-store-guardrail.R
@@ -1,0 +1,82 @@
+# tests/testthat/test-stable-id-store-guardrail.R
+# TDD guardrail: .warn_if_global_store_in_session warns when the process-global
+# .stable_id_counters default is used while a Shiny reactive domain is active.
+#
+# Background (L24): the process-global default is only safe for unit tests /
+# non-Shiny use. A future caller inside a live Shiny session without an explicit
+# store= would silently share counters across concurrent users causing cross-
+# session ID collisions. The warning surfaces this misuse early.
+
+source_for_test("functions/data_structure.R")
+
+# ── Assertion 1 ──────────────────────────────────────────────────────────────
+# generate_stable_element_id() with global default INSIDE a session → warns
+test_that("generate_stable_element_id warns when using global store inside a Shiny session", {
+  sess <- shiny::MockShinySession$new()
+  shiny::withReactiveDomain(sess, {
+    expect_warning(
+      generate_stable_element_id("ES"),
+      regexp = "session-local"
+    )
+  })
+})
+
+# ── Assertion 2 ──────────────────────────────────────────────────────────────
+# generate_stable_element_id() with EXPLICIT session store inside a session → silent
+test_that("generate_stable_element_id is silent when given an explicit session store inside a Shiny session", {
+  sess <- shiny::MockShinySession$new()
+  shiny::withReactiveDomain(sess, {
+    my_store <- new_stable_id_store()
+    expect_silent(
+      generate_stable_element_id("ES", store = my_store)
+    )
+  })
+})
+
+# ── Assertion 3 ──────────────────────────────────────────────────────────────
+# Outside any reactive domain: global default is fine (no Shiny session active)
+test_that("generate_stable_element_id is silent with global default OUTSIDE any reactive domain", {
+  # getDefaultReactiveDomain() returns NULL here → no warning expected
+  expect_silent(
+    generate_stable_element_id("ES")
+  )
+})
+
+# ── Assertion 4 ──────────────────────────────────────────────────────────────
+# reconcile_loaded_element_ids() with global default INSIDE a session → warns ONCE
+test_that("reconcile_loaded_element_ids warns once (not multiple times) when using global store inside a Shiny session", {
+  sess <- shiny::MockShinySession$new()
+  shiny::withReactiveDomain(sess, {
+    df <- data.frame(ID = c("ES001", "ES001"), stringsAsFactors = FALSE)
+    # Capture warnings — must have exactly one matching the guardrail message,
+    # not multiple (the inner seed_/generate_ calls receive an explicit store so
+    # missing() is FALSE there and they do NOT double-warn).
+    w <- withCallingHandlers(
+      {
+        reconcile_loaded_element_ids(df, "ES")
+        NULL
+      },
+      warning = function(cond) {
+        invokeRestart("muffleWarning")
+      }
+    )
+    # Use expect_warning which captures the warning count via tryCatch
+    expect_warning(
+      reconcile_loaded_element_ids(df, "ES"),
+      regexp = "session-local"
+    )
+
+    # Confirm exactly ONE guardrail warning (not two from inner helpers)
+    warnings_caught <- character(0)
+    withCallingHandlers(
+      reconcile_loaded_element_ids(df, "ES"),
+      warning = function(cond) {
+        warnings_caught <<- c(warnings_caught, conditionMessage(cond))
+        invokeRestart("muffleWarning")
+      }
+    )
+    guardrail_warnings <- warnings_caught[grepl("session-local", warnings_caught)]
+    expect_equal(length(guardrail_warnings), 1L,
+      info = "reconcile should warn exactly once (inner seed_/generate_ get explicit store)")
+  })
+})


### PR DESCRIPTION
Phase G of the 2026-06-03 code-review fix plan, **rescoped by a call-site audit** (the plan's audit-first amendment). The audit found Phase G is mostly NOT live cross-session state; this PR ships the one item with real value.

## G3 / L24 — latent stable-ID-store foot-gun (the fix)
The 4 stable-id allocators in `functions/data_structure.R` default `store = .stable_id_counters` (process-global). All current production paths already pass a session-local store (`isa_data_entry_module` passes `id_store`; `normalize_and_reconcile_project` coerces a NULL store to a fresh `new_stable_id_store()`), so there is **no live bug** — but a *future* caller omitting `store=` inside a live session would silently share counters across users → cross-session ID collisions (broken LinkedX refs).

**Fix:** a warn-only guardrail. Each allocator calls `.warn_if_global_store_in_session(missing(store))` as its first line; it `warning()`s only when the default store is used **and** a Shiny session is active (`shiny::getDefaultReactiveDomain()` non-NULL). No allocation behavior changes; the global default still works for unit tests / non-Shiny use, and `reconcile_loaded_element_ids` passes `store` explicitly downstream so it warns exactly once.

New behavioral tests (`test-stable-id-store-guardrail.R`, via `withReactiveDomain(MockShinySession$new())`): default-in-session warns; explicit store silent; no-domain silent; reconcile warns exactly once.

## Audit dispositions for the rest of Phase G (no code here)
- **H1/G1** (graph/feature caches): **dead** — zero live module/server callers → demote to Phase K (cleanup).
- **L1/G4** (i18n translator): session language already session-local; the global-translator borrow is atomic under R's single-threaded-per-worker model → **no change** (clone-per-session rewrite would risk a working system for no real gain).
- **L4/G6**: already a per-session `reactiveVal` → low intra-session nuance only.
- **L2/G2** (ML singleton): load-time only on single-threaded R → low.
- **L3/G5** (scenario read-modify-write): genuine moderate edge case → optional follow-up.

## Verification
Full suite **7816 pass / 0 fail**; zero spurious guardrail warnings across the suite. i18n unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation checks to detect and warn when stable element ID configuration is used improperly within Shiny sessions, preventing potential ID allocation conflicts.

* **Tests**
  * Added test coverage to verify warning behavior for stable element ID functions across different Shiny session contexts and store configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->