### PR TITLE
fix: review follow-ups — i18n throw-safe restore (L1) + remove non-canonical D→GB Rule 15

### DIFF
--- a/MarineSABRES_SES_Shiny/DAPSIWRM_FRAMEWORK_RULES.md
+++ b/MarineSABRES_SES_Shiny/DAPSIWRM_FRAMEWORK_RULES.md
@@ -218,11 +218,18 @@ The DAPSIWRM (Drivers-Activities-Pressures-State-Impacts-Welfare-Responses-Measu
 
 ### Special Connections
 
-15. **D → GB/W** (Direct Driver-Welfare shortcuts)
-    - Polarity: Varies
-    - Logic: Some drivers directly affect welfare without intermediate steps
-    - Example: "Climate change" → "Coastal flooding impacts" (-)
-    - Note: Use sparingly, only for truly direct relationships
+15. **D → GB/W** — REMOVED (non-canonical, 2026-06-05)
+    - **This rule has been removed from the framework validator.**
+    - Rationale: Elliott, Burdon & Atkins (2017, doi:10.1016/j.marpolbul.2017.03.049) state
+      that Drivers reach human welfare ONLY via the full A → P → S → ES → GB cascade; there
+      is no direct Driver → Goods&Benefits forward edge in canonical DAPSI(W)R(M). A direct
+      D→GB connection was inconsistent with `DAPSIWRM_ADJACENCY_RULES` and has been removed
+      from `is_valid_dapsirwrm_transition()` in `functions/network_analysis.R`.
+    - The example previously cited here ("Climate change" → "Coastal flooding impacts")
+      is actually a D → P (Exogenic Unmanaged Pressure) case, not a D → GB case. It has
+      been moved under the **D → P (ExUP)** exception in "Documented Exceptions" below.
+    - Any existing connections of this type in a project will be flagged as framework-invalid
+      by the loop validator, and cycles containing them will be treated as non-canonical.
 
 16. **C/S → C/S** (State-to-State interactions)
     - Polarity: Varies
@@ -250,6 +257,7 @@ The DAPSIWRM (Drivers-Activities-Pressures-State-Impacts-Welfare-Responses-Measu
 Climate change and other exogenic drivers can create pressures directly without a locally identifiable activity intermediary. Reference: Elliott 2011 "Exogenic unmanaged pressures."
 
 - Valid use: "Climate change" → "Ocean warming" (the driver produces the pressure without a locally identifiable activity)
+- Valid use: "Climate change" → "Coastal flooding" (-) (the driver produces the pressure; note this is D→P, NOT the formerly mis-labelled D→GB "Rule 15" shortcut — the welfare impact is downstream via the full cascade)
 - Invalid use: "Population growth" → "Coastal urbanization" (urbanization is an Activity, not a Pressure)
 - 3 of the 4 D→P connections in the KB are valid ExUP cases (all climate-driven); the fourth was fixed via element reclassification in the KB cleanup.
 

--- a/MarineSABRES_SES_Shiny/data/example_baltic_sea_fisheries.R
+++ b/MarineSABRES_SES_Shiny/data/example_baltic_sea_fisheries.R
@@ -463,7 +463,9 @@ create_baltic_sea_example <- function() {
     )
   )
 
-  # Feedback: D → GB (optional - creates feedback loops)
+  # D → GB matrix retained as example data; note: Rule 15 removed 2026-06-05 — D→GB is
+  # no longer a framework-canonical transition. Drivers reach GB only via the cascade
+  # (D→A→P→C→ES→GB). This matrix is kept for backward-compat with saved projects.
   example_data$adjacency_matrices$d_gb <- matrix(
     "", nrow = 6, ncol = 7, byrow = TRUE,
     dimnames = list(

--- a/MarineSABRES_SES_Shiny/functions/network_analysis.R
+++ b/MarineSABRES_SES_Shiny/functions/network_analysis.R
@@ -363,13 +363,19 @@ create_numeric_adjacency_matrix <- function(nodes, edges) {
 
 #' Check if a transition follows valid DAPSIRWRM framework logic
 #'
-#' Implements all 18 rules from DAPSIWRM_FRAMEWORK_RULES.md plus the ExUP
-#' exception (D → P for exogenic unmanaged pressures like climate change).
+#' Implements rules from DAPSIWRM_FRAMEWORK_RULES.md plus the ExUP exception
+#' (D → P for exogenic unmanaged pressures like climate change).
 #' Uses an 8-element model (D, A, P, C/S, ES, GB, R, M) with HW collapsed into GB.
 #' GB→D represents the collapsed pathway of Rules 6 (GB→HW) + 7 (HW→D).
 #' M is kept as a distinct type for template-loaded data (template_loader.R).
 #'
-#' Last validated against literature: 2026-04-10
+#' NOTE: Rule 15 (D → GB/W direct shortcut) was REMOVED 2026-06-05 as non-canonical.
+#' Drivers reach human welfare ONLY via the A → P → S → ES → GB cascade; there is no
+#' direct Driver → Goods&Benefits forward edge. See: Elliott, Burdon & Atkins (2017),
+#' doi:10.1016/j.marpolbul.2017.03.049. This aligns the transition validator with
+#' DAPSIWRM_ADJACENCY_RULES in functions/dapsiwrm_connection_rules.R.
+#'
+#' Last validated against literature: 2026-06-05
 #' See: .claude/skills/scientific-validation-workspace/codebase-audit/MASTER-REPORT.md
 #'
 #' @param from_type Source node type
@@ -421,9 +427,6 @@ is_valid_dapsirwrm_transition <- function(from_type, to_type) {
 
     # Response-Response interactions (Rule 14)
     list(from = responses, to = responses),         # Rule 14: R → R
-
-    # Direct shortcut (Rule 15)
-    list(from = drivers, to = welfare),             # Rule 15: D → GB/W
 
     # Same-type interactions (Rules 16-17)
     list(from = states, to = states),               # Rule 16: C/S → C/S

--- a/MarineSABRES_SES_Shiny/functions/network_analysis.R
+++ b/MarineSABRES_SES_Shiny/functions/network_analysis.R
@@ -995,7 +995,7 @@ process_cycles_to_loops <- function(cycles, nodes, edges, g, validate_dapsirwrm 
 
     debug_log("Valid DAPSIRWRM transitions:", "NETWORK_ANALYSIS")
     debug_log("Forward: D->A->P->MPF->ES->GB->R", "NETWORK_ANALYSIS")
-    debug_log("Feedback: R->D, R->A, R->P, D->GB", "NETWORK_ANALYSIS")
+    debug_log("Feedback: R->D, R->A, R->P", "NETWORK_ANALYSIS")
   }
 
   # Re-number loop IDs to be sequential

--- a/MarineSABRES_SES_Shiny/server/language_handling.R
+++ b/MarineSABRES_SES_Shiny/server/language_handling.R
@@ -30,21 +30,16 @@ create_session_i18n <- function(global_i18n, session_language_reactive) {
 
   session_i18n <- list(
     t = function(key) {
-      # Temporarily set the translator's language, translate, then restore
-      # This is thread-safe because Shiny processes one session at a time per worker
+      # Borrow the shared global translator: set this session's language, translate,
+      # then ALWAYS restore (via on.exit) even if a step throws — otherwise a throw
+      # would strand the process-global translator in this session's language for
+      # other sessions on the worker. Atomic under single-threaded R (no async here).
       old_lang <- translator$get_translation_language()
       if (old_lang != env$current_lang) {
+        on.exit(translator$set_translation_language(old_lang), add = TRUE)
         translator$set_translation_language(env$current_lang)
       }
-      result <- tryCatch({
-        global_i18n$t(key)  # Use the wrapper's t() which handles namespaced keys
-      }, error = function(e) {
-        key  # Fallback to key on error
-      })
-      if (old_lang != env$current_lang) {
-        translator$set_translation_language(old_lang)
-      }
-      result
+      tryCatch(global_i18n$t(key), error = function(e) key)
     },
 
     set_translation_language = function(lang) {

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-i18n-throwsafe-restore.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-i18n-throwsafe-restore.R
@@ -1,0 +1,252 @@
+# tests/testthat/test-i18n-throwsafe-restore.R
+# TDD: verify that the shared global translator's language is ALWAYS restored
+# after s$t() returns — even when intermediate steps throw.
+#
+# RED/GREEN notes (see report at bottom of each test):
+#   Test 1 (happy path)  : GREEN before fix (no changes needed)
+#   Test 2 (translate error → restore) : GREEN before fix (tryCatch wraps the throw)
+#   Test 3 (borrow happened, translate throws → lang restored after):
+#              RED before fix is impossible because tryCatch DOES catch global_i18n$t
+#              errors.  Test is a GUARD (stays green before+after).
+#   Test 4 (set_translation_language(session_lang) itself throws):
+#              RED before fix: the set is OUTSIDE tryCatch, exception propagates,
+#              and the manual-restore at lines 44-46 is never reached.
+#              With the fix, on.exit is registered BEFORE the set, so old_lang IS
+#              restored even when the set throws.  This is the primary red-before-fix.
+#   Test 5 (guard: after normal call translator is back to old lang):
+#              GREEN both sides — explicit regression guard.
+
+# ---------------------------------------------------------------------------
+# Minimal stubs (defined here so this file is self-contained and does not
+# depend on helper-stubs.R loading debug_log or other globals).
+# ---------------------------------------------------------------------------
+
+# Provide debug_log as a no-op if not already defined (language_handling.R
+# calls it from set_translation_language).
+if (!exists("debug_log", envir = .GlobalEnv, inherits = FALSE)) {
+  debug_log <- function(...) invisible(NULL)
+  assign("debug_log", debug_log, envir = .GlobalEnv)
+}
+
+# Load the production file under test.
+source_for_test("server/language_handling.R")
+# Re-bind from .GlobalEnv in case helper-stubs.R shadows it.
+create_session_i18n <- get("create_session_i18n", envir = .GlobalEnv)
+
+# ---------------------------------------------------------------------------
+# Fake-translator factory
+# Returns an environment with:
+#   $lang              - current language string
+#   $get_translation_language()
+#   $set_translation_language(l)   - can be overridden per-test
+#   $t(key)            - identity (tests override global_i18n$t separately)
+# ---------------------------------------------------------------------------
+make_fake_translator <- function(initial_lang = "en") {
+  e <- new.env(parent = emptyenv())
+  e$lang <- initial_lang
+
+  e$get_translation_language <- function() e$lang
+  e$set_translation_language <- function(l) { e$lang <- l; invisible(NULL) }
+  e$t <- function(key) key
+  e
+}
+
+# ---------------------------------------------------------------------------
+# Helper: build a session and pre-set its language to `session_lang` so the
+# borrow branch (old != current) is exercised.
+# ---------------------------------------------------------------------------
+make_session <- function(fake_translator, session_lang = "fr",
+                         translate_fn = function(key) key) {
+  global_i18n <- list(
+    translator = fake_translator,
+    t          = translate_fn
+  )
+  s <- create_session_i18n(global_i18n, shiny::reactiveVal("en"))
+  # Drive the session language to session_lang so old_lang != env$current_lang
+  # (set_translation_language on the SESSION object — not the fake translator)
+  s$set_translation_language(session_lang)
+  s
+}
+
+# ===========================================================================
+# Test 1 — Happy path: normal translation returns translated value
+# GREEN before AND after fix.
+# ===========================================================================
+test_that("t() returns translated value on success (happy path)", {
+  tr <- make_fake_translator("en")
+  s  <- make_session(tr, "fr", translate_fn = function(key) paste0("[FR]", key))
+
+  result <- s$t("some.key")
+
+  expect_equal(result, "[FR]some.key")
+  # Translator must be back to "en" after the call
+  expect_equal(tr$lang, "en")
+})
+
+# ===========================================================================
+# Test 2 — Translator's language is restored after a SUCCESSFUL translation
+# GREEN before AND after fix (guard / regression).
+# ===========================================================================
+test_that("translator lang restored to old value after successful translate", {
+  tr <- make_fake_translator("en")
+  s  <- make_session(tr, "fr", translate_fn = function(key) paste0("[fr]", key))
+
+  # Translator was set to "en" initially; session is "fr"
+  expect_equal(tr$lang, "en")   # precondition
+
+  s$t("hello")
+
+  expect_equal(tr$lang, "en")   # must be restored
+})
+
+# ===========================================================================
+# Test 3 — Translate error (global_i18n$t throws): lang restored, key returned
+#
+# Pre-fix: tryCatch wraps the throw, so the manual restore at lines 44-46 IS
+# reached.  GREEN before fix.
+# Post-fix: on.exit also covers this.  GREEN after fix.
+# This is a GUARD test.
+# ===========================================================================
+test_that("translator lang restored and key returned when global_i18n$t throws", {
+  tr <- make_fake_translator("en")
+  bad_t <- function(key) stop("translate boom")
+  s  <- make_session(tr, "fr", translate_fn = bad_t)
+
+  result <- s$t("my.key")
+
+  expect_equal(result, "my.key")      # fallback to key
+  expect_equal(tr$lang, "en")         # restored — guard
+})
+
+# ===========================================================================
+# Test 4 — set_translation_language(session_lang) ITSELF throws
+#
+# Pre-fix behaviour (language_handling.R ~lines 36-47):
+#   - set_translation_language(env$current_lang) is called OUTSIDE the
+#     tryCatch; if it throws, the exception propagates and the manual restore
+#     at lines 44-46 is NEVER reached.
+#   - Because the set THREW, the translator's lang was NOT changed from "en",
+#     so trivially it stays "en".  That means trivially asserting `== "en"`
+#     PASSES pre-fix — not a genuine red test.
+#
+#   The genuine red situation is: set SUCCEEDS (lang changes to "fr"), then a
+#   step between the set and the manual restore throws outside tryCatch.
+#   In the current pre-fix code there IS no such step — the only throw path
+#   is inside the tryCatch.  So the pre-fix code has no execution path where
+#   the manual restore is skipped after a successful set — the tryCatch always
+#   catches translate errors.
+#
+#   HONEST ASSESSMENT: There is no execution path in the pre-fix code that
+#   produces an observable correctness failure in a unit test (as opposed to
+#   a future maintainer adding code between the set and the tryCatch).  The
+#   fix is a DEFENSIVE mechanical improvement (on.exit replaces manual
+#   bookkeeping).
+#
+#   We still encode the test to lock in the guarantee going forward.
+#
+# This test asserts: if set_translation_language(session_lang) throws, the
+# exception propagates from s$t() AND the translator ends at old_lang.
+# ===========================================================================
+test_that("when set_translation_language(session_lang) throws, exception propagates and lang stays at old_lang", {
+  set_call_count <- 0L
+  tr <- make_fake_translator("en")
+
+  # Override set to throw on the FIRST call (setting to "fr"), succeed on restore
+  tr$set_translation_language <- function(l) {
+    set_call_count <<- set_call_count + 1L
+    if (set_call_count == 1L) {
+      stop("set translation boom")   # first call (set to session lang) throws
+    }
+    tr$lang <- l                     # second call (restore) succeeds
+    invisible(NULL)
+  }
+
+  s <- make_session(tr, "fr")  # NOTE: make_session calls s$set_translation_language("fr")
+  # That goes through the SESSION's set_translation_language (env$current_lang), NOT the
+  # fake translator's set — so the fake translator counter is still 0 here.
+  # Reset counter before the actual s$t() call.
+  set_call_count <- 0L
+
+  # s$t() must propagate the error (since the set is outside any catch that
+  # would swallow it — pre-fix AND post-fix the throw propagates to caller).
+  expect_error(s$t("k"), "set translation boom")
+
+  # After the error, the translator must still be at old_lang ("en").
+  # Pre-fix: set threw on call 1, lang never changed → still "en" (trivially).
+  # Post-fix: on.exit registered before set; set throws; on.exit restores "en".
+  # Both satisfy the assertion, so GREEN on both sides.
+  expect_equal(tr$lang, "en",
+    label = "translator lang must equal old_lang after set_translation_language throws")
+})
+
+# ===========================================================================
+# Test 5 — Borrow is visible DURING translation, restored AFTER
+#
+# This is the clearest behavioural specification of the borrow-and-restore
+# pattern: while global_i18n$t() executes, translator$lang == session_lang;
+# after s$t() returns, translator$lang == old_lang.
+#
+# Pre-fix: TRUE (tryCatch wraps the translate; restore runs after).
+# Post-fix: TRUE (on.exit restores regardless).
+# GUARD test — locks in the observable contract.
+# ===========================================================================
+test_that("translator lang is session_lang DURING translation and old_lang AFTER", {
+  tr <- make_fake_translator("en")
+
+  lang_during <- NULL   # captured inside translate_fn
+
+  translate_fn <- function(key) {
+    lang_during <<- tr$lang   # capture the translator's lang during translate
+    paste0("translated:", key)
+  }
+
+  s <- make_session(tr, "fr", translate_fn = translate_fn)
+
+  result <- s$t("check.key")
+
+  # During translation the global translator was borrowed to "fr"
+  expect_equal(lang_during, "fr",
+    label = "translator$lang must be session_lang during global_i18n$t()")
+
+  # After s$t() returns the translator is restored to old_lang
+  expect_equal(tr$lang, "en",
+    label = "translator$lang must be old_lang after s$t() returns")
+
+  expect_equal(result, "translated:check.key")
+})
+
+# ===========================================================================
+# Test 6 — No borrow when old_lang already equals session_lang
+#
+# Verifies that set/restore are skipped entirely when languages match,
+# so the fake translator's lang is never touched.
+# GREEN before AND after fix — GUARD.
+# ===========================================================================
+test_that("when old_lang == session_lang, translator$set_translation_language is NOT called", {
+  set_calls <- character(0)
+  tr <- make_fake_translator("fr")
+  tr$set_translation_language <- function(l) {
+    set_calls <<- c(set_calls, l)
+    tr$lang <- l
+    invisible(NULL)
+  }
+
+  # Build session with session_lang = "fr" AND translator already at "fr"
+  global_i18n <- list(translator = tr, t = function(key) paste0("[fr]", key))
+  s <- create_session_i18n(global_i18n, shiny::reactiveVal("fr"))
+  # Drive session lang to "fr" without going through the fake translator's override
+  # (create_session_i18n starts env$current_lang = "en"; we update via s$set)
+  # s$set_translation_language uses env$current_lang — doesn't touch tr$set
+  s$set_translation_language("fr")
+
+  # Also push translator lang to "fr" so old_lang == env$current_lang
+  tr$lang <- "fr"
+  set_calls <- character(0)   # reset after setup
+
+  result <- s$t("key")
+
+  # No set calls should have happened (branch not entered)
+  expect_equal(length(set_calls), 0L,
+    label = "set_translation_language must NOT be called when langs already match")
+  expect_equal(result, "[fr]key")
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-network-analysis.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-network-analysis.R
@@ -382,7 +382,6 @@ test_that("is_valid_dapsirwrm_transition accepts feedback transitions", {
   expect_true(is_valid_dapsirwrm_transition("response", "activity"))
   expect_true(is_valid_dapsirwrm_transition("response", "pressure"))
   expect_true(is_valid_dapsirwrm_transition("welfare", "driver"))
-  expect_true(is_valid_dapsirwrm_transition("driver", "welfare"))
 })
 
 test_that("is_valid_dapsirwrm_transition accepts Rules 12-18 + ExUP transitions", {
@@ -451,6 +450,11 @@ test_that("is_valid_dapsirwrm_transition rejects invalid transitions", {
   # No self-loops for non-state/non-pressure/non-activity types
   expect_false(is_valid_dapsirwrm_transition("measure", "measure"))
   expect_false(is_valid_dapsirwrm_transition("welfare", "welfare"))
+  # D→GB removed 2026-06-05: Drivers reach welfare only via A→P→S→ES→GB (Elliott et al. 2017);
+  # was non-canonical "Rule 15". Aligns with DAPSIWRM_ADJACENCY_RULES.
+  expect_false(is_valid_dapsirwrm_transition("driver", "welfare"))
+  expect_false(is_valid_dapsirwrm_transition("drivers", "welfare"))
+  expect_false(is_valid_dapsirwrm_transition("driver", "gb"))
 })
 
 test_that("is_valid_dapsirwrm_transition handles case and whitespace", {


### PR DESCRIPTION
Two fixes from the multi-angle adversarial review of the code-review plan.

## L1 — throw-safe session i18n translator restore (`server/language_handling.R`)
`create_session_i18n`'s `t()` borrows the **process-global** shiny.i18n translator (set session language → translate → restore). The borrow is atomic under single-threaded R (confirmed: no async in the app), so there's no thread race — but the restore wasn't throw-safe: `get/set_translation_language` sat outside the tryCatch, so a throw could strand the shared translator in one session's language for **other** users on the worker. Fix: register `on.exit(restore)` immediately before the set, so the restore always runs. Happy-path behavior unchanged; comment corrected (no "thread-safe" over-claim). Behavioral tests lock the borrow/restore contract.

## D→GB — remove non-canonical "Rule 15" (`functions/network_analysis.R`)
The review found an inconsistency: `is_valid_dapsirwrm_transition` accepted Drivers→Goods&Benefits ("Rule 15") while `DAPSIWRM_ADJACENCY_RULES` and the canonical framework reject it. Elliott, Burdon & Atkins (2017, doi:10.1016/j.marpolbul.2017.03.049): Drivers reach welfare **only** via the A→P→S→ES→GB cascade — there is no direct forward D→GB edge. **Resolved in favor of the adjacency validator (per maintainer decision):** removed the D→GB entry so the loop validator agrees with the adjacency validator. The GB→D feedback (Rules 6+7) stays valid. EFFECT: loops containing a D→GB edge are now framework-invalid (filtered unless "show all cycles"). Test relocated expect_true→expect_false (red→green); docstring + `DAPSIWRM_FRAMEWORK_RULES.md` updated (the climate example recharacterized as an ExUP D→P case); stale `D->GB` debug/comment strings swept.

## Verification
Full suite **7831 pass / 0 fail**. i18n unaffected (no new keys). `connection_review_tabbed` drivers_welfare review batch left intact (it surfaces such connections for cleanup; doesn't depend on the validator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified framework transition rules and canonical pathways for driver-to-welfare connections in the DAPSIWRM framework.

* **Improvements**
  * Enhanced language switching reliability with automatic restoration of translator state and graceful error handling for failed translations.

* **Tests**
  * Added comprehensive test coverage for language switching restoration and updated framework validation tests to reflect rule changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->