### PR TITLE
feat(decision-lens): QSEM factor-classification module (Phase 1)

### DIFF
--- a/MarineSABRES_SES_Shiny/app.R
+++ b/MarineSABRES_SES_Shiny/app.R
@@ -94,6 +94,7 @@ OPTIONAL_MODULES <- c(
   "modules/analysis_bot.R",              # BOT (Behaviour Over Time) Analysis
   "modules/analysis_simplify.R",         # Network Simplification Tools
   "modules/analysis_leverage.R",         # Leverage Point Analysis
+  "modules/analysis_decision_lens.R",    # Decision Lens (QSEM factor classification)
   "modules/response_module.R",           # Response measures (includes response_validation_server())
   "modules/scenario_builder_module.R",   # Scenario Builder
   "modules/prepare_report_module.R",     # Report preparation (comprehensive)
@@ -489,6 +490,7 @@ ui <- bs4DashPage(
       bs4TabItem(tabName = "analysis_metrics", analysis_metrics_ui("analysis_met", i18n)),
       bs4TabItem(tabName = "analysis_loops", analysis_loops_ui("analysis_loop", i18n)),
       bs4TabItem(tabName = "analysis_leverage", analysis_leverage_ui("analysis_lev", i18n)),
+      bs4TabItem(tabName = "analysis_decision_lens", analysis_decision_lens_ui("analysis_dl", i18n)),
       bs4TabItem(tabName = "analysis_bot", analysis_bot_ui("analysis_b", i18n)),
       bs4TabItem(tabName = "analysis_simplify", analysis_simplify_ui("analysis_simp", i18n)),
       bs4TabItem(tabName = "analysis_boolean", analysis_boolean_ui("analysis_bool", i18n)),
@@ -1047,6 +1049,7 @@ server <- function(input, output, session) {
   analysis_metrics_server("analysis_met", project_data, session_i18n, event_bus = event_bus)
   analysis_loops_server("analysis_loop", project_data, session_i18n, event_bus = event_bus)
   analysis_leverage_server("analysis_lev", project_data, session_i18n, event_bus = event_bus)
+  analysis_decision_lens_server("analysis_dl", project_data, session_i18n, event_bus = event_bus)
   analysis_bot_server("analysis_b", project_data, session_i18n, event_bus = event_bus)
   analysis_simplify_server("analysis_simp", project_data, session_i18n, event_bus = event_bus)
 

--- a/MarineSABRES_SES_Shiny/functions/decision_lens.R
+++ b/MarineSABRES_SES_Shiny/functions/decision_lens.R
@@ -1,0 +1,141 @@
+# =============================================================================
+# DECISION LENS — QSEM-inspired interpretation helpers
+# File: functions/decision_lens.R
+# =============================================================================
+# Pure, Shiny-free helpers composing existing network analysis functions.
+# Phase 1 (shipping): classify_factors_micmac() — factor classification
+#   (impact-vs-control axis), surfacing the dormant MICMAC analysis.
+# Archetype detection + fused narrative are DEFERRED pending re-derivation
+# against valid DAPSIWRM loop topology + scientific validation.
+# See docs/superpowers/specs/2026-06-21-decision-lens-qsem.md (§0, §5, §6).
+#
+# DATA MODEL (verified against functions/visnetwork_helpers.R:71-225):
+#   nodes$group holds FULL category names ("Drivers","Pressures",
+#   "Marine Processes & Functioning",...) and ids are PREFIXED ("D_1","MPF_3").
+#   Derive the short code with: sub("_[0-9]+$", "", id) -> D/A/P/MPF/ES/GB/R.
+#   There is no "C" (State == MPF) and no "M" (Measures merged into Responses).
+# =============================================================================
+
+#' DAPSIWRM short code from a prefixed node id
+#'
+#' @param id character vector of node ids (e.g. "D_1", "MPF_3")
+#' @return character vector of codes (e.g. "D", "MPF"); language-proof
+#' @keywords internal
+dl_code_from_id <- function(id) {
+  sub("_[0-9]+$", "", as.character(id))
+}
+
+#' Factor classification via MICMAC (influence vs dependence)
+#'
+#' Surfaces calculate_micmac_safe() as a display-ready, labelled table. This is
+#' the "impact vs control axis": influence (out-reach) vs dependence (in-reach),
+#' with a structural quadrant classification. MICMAC is unsigned and discards
+#' polarity/strength — the read is structural, not dynamical.
+#'
+#' @param nodes data.frame with id, label, group (full names)
+#' @param edges data.frame with from, to, polarity
+#' @return data.frame id,label,group,influence,dependence,quadrant
+#'   (0 rows, same columns, when MICMAC is NULL/empty)
+#' @export
+classify_factors_micmac <- function(nodes, edges) {
+  empty <- data.frame(
+    id = character(0), label = character(0), group = character(0),
+    influence = numeric(0), dependence = numeric(0), quadrant = character(0),
+    stringsAsFactors = FALSE
+  )
+
+  micmac <- calculate_micmac_safe(nodes, edges)
+  if (is.null(micmac) || nrow(micmac) == 0) return(empty)
+
+  idx <- match(micmac$id, nodes$id)
+  data.frame(
+    id         = micmac$id,
+    label      = nodes$label[idx],
+    group      = nodes$group[idx],
+    influence  = micmac$influence,
+    dependence = micmac$dependence,
+    quadrant   = micmac$quadrant,
+    stringsAsFactors = FALSE
+  )
+}
+
+# Internal: node ids of a loop row (NodeIDs is comma-joined)
+.dl_loop_nodes <- function(node_ids_str) {
+  if (is.null(node_ids_str) || is.na(node_ids_str) || !nzchar(node_ids_str)) {
+    return(character(0))
+  }
+  trimws(strsplit(node_ids_str, ",")[[1]])
+}
+
+#' Build a deterministic "why this matters" narrative for one node
+#'
+#' Fuses the node's MICMAC quadrant role, loop participation, and (when the
+#' archetype layer ships) archetype leverage membership into one HTML block.
+#' All text is emitted via i18n keys — deterministic, translatable, reviewable;
+#' never ML-generated. While archetype detection is deferred, callers pass
+#' `archetypes = list()` and only the quadrant + loop lines render.
+#'
+#' @param node_id character id (prefixed, e.g. "MPF_1")
+#' @param micmac data.frame from classify_factors_micmac
+#' @param loop_info data.frame with LoopID, Type, NodeIDs (or NULL)
+#' @param archetypes list from detect_archetypes (or list())
+#' @param i18n object with $t(key); falls back to identity if absent
+#' @return character HTML
+#' @export
+build_decision_narrative <- function(node_id, micmac, loop_info, archetypes, i18n) {
+  K <- "modules.analysis.decision_lens"
+  t <- if (!is.null(i18n) && is.function(i18n$t)) i18n$t else function(k, ...) k
+
+  row <- micmac[micmac$id == node_id, , drop = FALSE]
+  label <- if (nrow(row) > 0 && !is.na(row$label[1])) row$label[1] else node_id
+  parts <- character(0)
+
+  # 1. Quadrant role (structural language — see spec §7)
+  if (nrow(row) > 0) {
+    quad_key <- switch(row$quadrant[1],
+      "Influential" = paste0(K, ".quad_influential"),
+      "Relay"       = paste0(K, ".quad_relay"),
+      "Dependent"   = paste0(K, ".quad_dependent"),
+      "Autonomous"  = paste0(K, ".quad_autonomous"),
+      paste0(K, ".quad_autonomous")
+    )
+    parts <- c(parts, paste0("<p><strong>", label, "</strong> — ", t(quad_key), "</p>"))
+  }
+
+  # 2. Loop participation
+  if (!is.null(loop_info) && nrow(loop_info) > 0) {
+    in_loops <- vapply(seq_len(nrow(loop_info)),
+                       function(i) node_id %in% .dl_loop_nodes(loop_info$NodeIDs[i]),
+                       logical(1))
+    if (any(in_loops)) {
+      n_r <- sum(in_loops & loop_info$Type == "Reinforcing")
+      n_b <- sum(in_loops & loop_info$Type == "Balancing")
+      fmt <- t(paste0(K, ".narrative_in_loops"))
+      # Defensive: real key contains "%d ... %d"; if a translation drops the
+      # specifiers (or under a key-echo test stub), fall back to plain append
+      # instead of letting sprintf warn/error.
+      loop_line <- if (grepl("%d", fmt, fixed = TRUE)) {
+        sprintf(fmt, n_r, n_b)
+      } else {
+        paste0(fmt, " (R: ", n_r, ", B: ", n_b, ")")
+      }
+      parts <- c(parts, paste0("<p>", loop_line, "</p>"))
+    }
+  }
+
+  # 3. Archetype leverage (deferred: archetypes is list() for now)
+  for (a in archetypes) {
+    if (!is.null(a$leverage_node_id) && a$leverage_node_id == node_id) {
+      parts <- c(parts, paste0(
+        "<p>", t(paste0(K, ".narrative_archetype_leverage")),
+        " <strong>", t(paste0(K, ".archetype.", a$archetype_key, ".name")), "</strong>: ",
+        t(paste0(K, ".archetype.", a$archetype_key, ".leverage")), "</p>"
+      ))
+    }
+  }
+
+  # 4. Always: confirm with stakeholders
+  parts <- c(parts, paste0("<p><em>", t(paste0(K, ".narrative_confirm")), "</em></p>"))
+
+  paste(parts, collapse = "\n")
+}

--- a/MarineSABRES_SES_Shiny/functions/tool_recommendations.R
+++ b/MarineSABRES_SES_Shiny/functions/tool_recommendations.R
@@ -66,6 +66,22 @@ get_next_steps <- function(current_module) {
         icon            = "sync-alt",
         description_key = "modules.tool_recommendations.metrics.loops_desc"
       )
+    ),
+    # Decision Lens reuses existing leverage/loops recommendation copy to avoid
+    # introducing new i18n keys (the linked tools are the natural next steps).
+    analysis_decision_lens = list(
+      list(
+        label_key       = "modules.tool_recommendations.metrics.leverage_label",
+        tab_id          = "analysis_leverage",
+        icon            = "crosshairs",
+        description_key = "modules.tool_recommendations.metrics.leverage_desc"
+      ),
+      list(
+        label_key       = "modules.tool_recommendations.metrics.loops_label",
+        tab_id          = "analysis_loops",
+        icon            = "sync-alt",
+        description_key = "modules.tool_recommendations.metrics.loops_desc"
+      )
     )
   )
 

--- a/MarineSABRES_SES_Shiny/functions/ui_sidebar.R
+++ b/MarineSABRES_SES_Shiny/functions/ui_sidebar.R
@@ -354,6 +354,11 @@ generate_sidebar_menu <- function(user_level = "intermediate", i18n) {
             tooltip_text = safe_t("ui.sidebar.tooltip.leverage_point_analysis", i18n_obj = i18n)
           ),
           add_submenu_tooltip(
+            safe_t("ui.sidebar.decision_lens", i18n_obj = i18n),
+            tabName = "analysis_decision_lens",
+            tooltip_text = safe_t("ui.sidebar.tooltip.decision_lens", i18n_obj = i18n)
+          ),
+          add_submenu_tooltip(
             safe_t("ui.sidebar.bot_analysis", i18n_obj = i18n),
             tabName = "analysis_bot",
             tooltip_text = safe_t("ui.sidebar.tooltip.bot_analysis", i18n_obj = i18n)

--- a/MarineSABRES_SES_Shiny/global.R
+++ b/MarineSABRES_SES_Shiny/global.R
@@ -668,6 +668,9 @@ source(get_project_file("functions", "async_helpers.R"), local = FALSE)
 # Cross-tool recommendation engine (next-steps links after analysis completion)
 source("functions/tool_recommendations.R", local = FALSE)  # FALSE = global scope for module access
 
+# Decision Lens (QSEM interpretation layer): factor classification helpers
+source("functions/decision_lens.R", local = FALSE)  # FALSE = global scope for module access
+
 # Root utils.R: Network visualization helpers (convert_strength, get_node_colors, get_node_shapes, etc.)
 source("utils.R", local = FALSE)  # FALSE = global scope for get_node_colors, get_node_shapes, etc.
 

--- a/MarineSABRES_SES_Shiny/modules/analysis_decision_lens.R
+++ b/MarineSABRES_SES_Shiny/modules/analysis_decision_lens.R
@@ -1,0 +1,176 @@
+# =============================================================================
+# MODULE: Decision Lens (QSEM interpretation layer)
+# File: modules/analysis_decision_lens.R
+# =============================================================================
+# Surfaces the dormant MICMAC factor classification (impact-vs-control axis) and
+# a deterministic "why this matters" narrative. Composes functions/decision_lens.R.
+#
+# Phase 1 scope: Factor Classification + Why This Matters tabs.
+# Archetype detection is DEFERRED (see the design spec §0/§6) pending
+# re-derivation against valid DAPSIWRM topology + scientific validation; the
+# Archetypes tab is intentionally omitted until that lands.
+# =============================================================================
+
+analysis_decision_lens_ui <- function(id, i18n) {
+  tryCatch(shiny.i18n::usei18n(i18n$translator %||% i18n), error = function(e) NULL)
+  ns <- NS(id)
+
+  tagList(
+    uiOutput(ns("module_header")),
+    fluidRow(column(12,
+      tabsetPanel(id = ns("dl_tabs"),
+
+        # Tab 1: Factor Classification (impact vs control) ----
+        tabPanel(i18n$t("modules.analysis.decision_lens.tab_factors"),
+          wellPanel(
+            p(i18n$t("modules.analysis.decision_lens.factors_intro")),
+            actionButton(ns("analyze"), i18n$t("modules.analysis.decision_lens.btn_analyze"),
+                         icon = icon("calculator"), class = "btn-primary")
+          ),
+          uiOutput(ns("factors_status")),
+          plotOutput(ns("factors_plot"), height = PLOT_HEIGHT_MD),
+          DT::dataTableOutput(ns("factors_table"))
+        ),
+
+        # Tab 2: Why This Matters ----
+        tabPanel(i18n$t("modules.analysis.decision_lens.tab_why"),
+          p(i18n$t("modules.analysis.decision_lens.why_intro")),
+          selectInput(ns("why_node"), NULL, choices = NULL),
+          htmlOutput(ns("why_narrative"))
+        )
+      )
+    )),
+    uiOutput(ns("next_steps_ui"))
+  )
+}
+
+analysis_decision_lens_server <- function(id, project_data_reactive, i18n, event_bus = NULL) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+    rv <- reactiveValues(factors = NULL, loop_info = NULL)
+
+    # Stale-data observer
+    observe({
+      req(!is.null(event_bus))
+      event_bus$on_isa_change()
+      if (!is.null(isolate(rv$factors))) {
+        showNotification(i18n$t("modules.analysis.common.data_changed_rerun"),
+                         type = "warning", duration = 5, id = ns("stale_data"))
+      }
+    })
+
+    create_reactive_header(
+      output = output, ns = ns,
+      title_key = "modules.analysis.decision_lens.title",
+      subtitle_key = "modules.analysis.decision_lens.subtitle",
+      help_id = "help_decision_lens", i18n = i18n
+    )
+
+    # Resolve nodes/edges/graph, reusing the cached igraph when available
+    resolve_graph <- function() {
+      cached <- if (!is.null(event_bus)) event_bus$get_isa_igraph() else NULL
+      if (!is.null(cached)) {
+        return(list(nodes = cached$nodes, edges = cached$edges, graph = cached$graph))
+      }
+      pd <- project_data_reactive()
+      isa <- pd$data$isa_data
+      if (is.null(isa)) return(NULL)
+      nodes <- create_nodes_df(isa)
+      edges <- create_edges_df(isa, isa$adjacency_matrices)
+      list(nodes = nodes, edges = edges, graph = NULL)
+    }
+
+    observeEvent(input$analyze, {
+      g <- resolve_graph()
+      if (is.null(g) || is.null(g$edges) || nrow(g$edges) == 0) {
+        showNotification(i18n$t("modules.analysis.decision_lens.no_network_data"),
+                         type = "warning", duration = 5)
+        return()
+      }
+      tryCatch({
+        rv$factors <- classify_factors_micmac(g$nodes, g$edges)
+
+        # Loops feed the narrative's loop-participation line (archetypes deferred)
+        gph <- g$graph
+        if (is.null(gph)) {
+          gph <- graph_from_data_frame(g$edges %>% select(from, to, polarity),
+                                       directed = TRUE,
+                                       vertices = g$nodes %>% select(id, label, group))
+        }
+        loops <- find_all_cycles(g$nodes, g$edges, max_length = 8, max_cycles = 500,
+                                 timeout_seconds = LOOP_ANALYSIS_TIMEOUT_SECONDS)
+        rv$loop_info <- process_cycles_to_loops(loops, g$nodes, g$edges, gph)
+
+        updateSelectInput(session, "why_node",
+                          choices = setNames(rv$factors$id, rv$factors$label))
+      }, error = function(e) {
+        showNotification(
+          format_user_error(e, i18n = i18n,
+                            context_key = "common.messages.context_analyzing_decision_lens"),
+          type = "error", duration = 10)
+      })
+    })
+
+    output$factors_status <- renderUI({
+      if (is.null(rv$factors)) {
+        div(class = "alert alert-info", icon("info-circle"), " ",
+            i18n$t("modules.analysis.decision_lens.click_analyze"))
+      } else NULL
+    })
+
+    output$factors_plot <- renderPlot({
+      req(rv$factors); req(nrow(rv$factors) > 0)
+      df <- rv$factors
+      # Quadrant dual-encoded (color + shape) so it does not rely on colour alone
+      ggplot(df, aes(x = dependence, y = influence, color = quadrant, shape = quadrant)) +
+        geom_vline(xintercept = median(df$dependence), linetype = "dashed", color = "grey60") +
+        geom_hline(yintercept = median(df$influence),  linetype = "dashed", color = "grey60") +
+        geom_point(size = 4, alpha = 0.85) +
+        geom_text(aes(label = label), size = 3.5, vjust = -1, check_overlap = TRUE,
+                  show.legend = FALSE) +
+        labs(x = i18n$t("modules.analysis.decision_lens.factors_x_axis"),
+             y = i18n$t("modules.analysis.decision_lens.factors_y_axis")) +
+        theme_minimal(base_size = 13)
+    })
+
+    output$factors_table <- DT::renderDataTable({
+      req(rv$factors)
+      DT::datatable(rv$factors, options = list(pageLength = 15, scrollX = TRUE),
+                    rownames = FALSE)
+    })
+
+    output$why_narrative <- renderUI({
+      req(input$why_node, rv$factors)
+      HTML(build_decision_narrative(input$why_node, rv$factors, rv$loop_info,
+                                    archetypes = list(), i18n))  # archetypes deferred
+    })
+
+    output$next_steps_ui <- renderUI({
+      req(!is.null(rv$factors))
+      build_next_steps_ui("analysis_decision_lens", ns, i18n)
+    })
+
+    local({
+      recs <- get_next_steps("analysis_decision_lens")
+      lapply(seq_along(recs), function(i) {
+        observeEvent(input[[paste0("next_step_", i)]], {
+          if (!is.null(event_bus) && is.function(event_bus$emit_navigation_request)) {
+            event_bus$emit_navigation_request(recs[[i]]$tab_id, "analysis_decision_lens")
+          }
+        })
+      })
+    })
+
+    create_help_observer(
+      input = input, input_id = "help_decision_lens",
+      title_key = "modules.analysis.decision_lens.help_title",
+      content = tagList(
+        p(i18n$t("modules.analysis.decision_lens.factors_intro")),
+        p(i18n$t("modules.analysis.decision_lens.why_intro"))
+      ),
+      i18n = i18n
+    )
+
+    return(reactive({ rv }))
+  })
+}

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-analysis-decision-lens-module.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-analysis-decision-lens-module.R
@@ -1,0 +1,17 @@
+# tests/testthat/test-analysis-decision-lens-module.R
+# Signature/contract test for the Decision Lens module.
+
+test_that("analysis_decision_lens module has the conventional UI and server contract", {
+  source_for_test("modules/analysis_decision_lens.R")
+  i18n <- list(t = function(k, ...) k, translator = NULL)
+
+  ui <- analysis_decision_lens_ui("dl", i18n)
+  expect_true(inherits(ui, "shiny.tag") || inherits(ui, "shiny.tag.list"))
+  # IDs must be namespaced under the module id
+  expect_true(grepl("dl-", as.character(ui), fixed = TRUE))
+
+  expect_true(is.function(analysis_decision_lens_server))
+  fmls <- names(formals(analysis_decision_lens_server))
+  expect_true(all(c("id", "project_data_reactive", "i18n") %in% fmls))
+  expect_true("event_bus" %in% fmls)
+})

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-decision-lens.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-decision-lens.R
@@ -1,0 +1,107 @@
+# tests/testthat/test-decision-lens.R
+# Unit tests for functions/decision_lens.R (QSEM Decision Lens pure helpers)
+
+# Self-contained load (mirrors test-network-analysis.R) so the file runs
+# standalone via testthat::test_file() as well as in the full suite.
+if (!exists("classify_factors_micmac") || !exists("calculate_micmac_safe")) {
+  tryCatch({
+    suppressPackageStartupMessages({
+      library(igraph)
+      library(dplyr)
+    })
+    source(file.path("..", "..", "functions", "network_analysis.R"), local = TRUE)
+    source(file.path("..", "..", "functions", "decision_lens.R"), local = TRUE)
+  }, error = function(e) {
+    skip(paste("Cannot load decision_lens.R deps:", e$message))
+  })
+}
+
+# Realistic fixture: FULL-NAME groups + PREFIXED ids, matching create_nodes_df
+# output (NOT fabricated short codes — see spec §0 data-model fix).
+make_fixture_nodes <- function() {
+  data.frame(
+    id    = c("D_1", "A_1", "P_1", "MPF_1"),
+    label = c("Driver", "Activity", "Pressure", "State"),
+    group = c("Drivers", "Activities", "Pressures", "Marine Processes & Functioning"),
+    stringsAsFactors = FALSE
+  )
+}
+make_fixture_edges <- function() {
+  data.frame(
+    from     = c("D_1", "A_1", "P_1", "MPF_1"),
+    to       = c("A_1", "P_1", "MPF_1", "D_1"),
+    polarity = c("+", "+", "-", "+"),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("dl_code_from_id strips the numeric suffix to the DAPSIWRM code", {
+  expect_equal(dl_code_from_id(c("D_1", "MPF_3", "GB_12", "R_2")),
+               c("D", "MPF", "GB", "R"))
+})
+
+test_that("classify_factors_micmac joins labels and full-name groups onto MICMAC output", {
+  res <- classify_factors_micmac(make_fixture_nodes(), make_fixture_edges())
+
+  expect_s3_class(res, "data.frame")
+  expect_equal(nrow(res), 4)
+  expect_setequal(names(res),
+                  c("id", "label", "group", "influence", "dependence", "quadrant"))
+  expect_setequal(res$label, c("Driver", "Activity", "Pressure", "State"))
+  # group stays the FULL category name (not a short code)
+  expect_true("Marine Processes & Functioning" %in% res$group)
+  expect_true(all(res$quadrant %in% c("Relay", "Influential", "Dependent", "Autonomous")))
+  expect_type(res$influence, "double")
+  expect_type(res$dependence, "double")
+})
+
+test_that("classify_factors_micmac returns empty frame with stable columns on no edges", {
+  res <- classify_factors_micmac(make_fixture_nodes(), edges = data.frame())
+  expect_equal(nrow(res), 0)
+  expect_setequal(names(res),
+                  c("id", "label", "group", "influence", "dependence", "quadrant"))
+})
+
+# ---------------------------------------------------------------------------
+# build_decision_narrative — i18n stub echoes keys so assertions are
+# language-independent.
+# ---------------------------------------------------------------------------
+test_that("build_decision_narrative fuses quadrant, loops, and archetype leverage", {
+  i18n <- list(t = function(k, ...) k)
+
+  micmac <- data.frame(
+    id = "P_1", label = "Pressure", group = "Pressures",
+    influence = 5, dependence = 2, quadrant = "Influential",
+    stringsAsFactors = FALSE
+  )
+  loop_info <- data.frame(
+    LoopID = c(1L, 2L), Type = c("Reinforcing", "Balancing"),
+    NodeIDs = c("D_1,A_1,P_1", "A_1,P_1,MPF_1"), stringsAsFactors = FALSE
+  )
+  archetypes <- list(list(
+    archetype_key = "limits_to_growth", loop_ids = c(1L, 2L),
+    node_ids = c("D_1", "A_1", "P_1", "MPF_1"), shared_node_ids = "A_1",
+    leverage_node_id = "P_1", confidence = "candidate"
+  ))
+
+  html <- build_decision_narrative("P_1", micmac, loop_info, archetypes, i18n)
+
+  expect_type(html, "character")
+  expect_match(html, "modules.analysis.decision_lens.quad_influential", fixed = TRUE)
+  expect_match(html, "modules.analysis.decision_lens.narrative_in_loops", fixed = TRUE)
+  expect_match(html, "modules.analysis.decision_lens.archetype.limits_to_growth.name", fixed = TRUE)
+  expect_match(html, "modules.analysis.decision_lens.narrative_confirm", fixed = TRUE)
+})
+
+test_that("build_decision_narrative omits archetype line when archetypes is empty (deferred path)", {
+  i18n <- list(t = function(k, ...) k)
+  micmac <- data.frame(id = "MPF_1", label = "State", group = "Marine Processes & Functioning",
+                       influence = 1, dependence = 6, quadrant = "Dependent",
+                       stringsAsFactors = FALSE)
+  loop_info <- data.frame(LoopID = 1L, Type = "Balancing",
+                          NodeIDs = "A_1,P_1,MPF_1", stringsAsFactors = FALSE)
+  html <- build_decision_narrative("MPF_1", micmac, loop_info, archetypes = list(), i18n)
+  expect_match(html, "modules.analysis.decision_lens.quad_dependent", fixed = TRUE)
+  expect_match(html, "modules.analysis.decision_lens.narrative_confirm", fixed = TRUE)
+  expect_false(grepl("narrative_archetype_leverage", html, fixed = TRUE))
+})

--- a/MarineSABRES_SES_Shiny/translations/common/messages.json
+++ b/MarineSABRES_SES_Shiny/translations/common/messages.json
@@ -858,6 +858,17 @@
       "no": "analyserer gearingspunkter",
       "el": "ανάλυση σημείων μόχλευσης"
     },
+    "common.messages.context_analyzing_decision_lens": {
+      "en": "running the decision lens",
+      "es": "ejecutando la lente de decisión",
+      "fr": "exécution de la loupe de décision",
+      "de": "Ausführen der Entscheidungslinse",
+      "lt": "vykdant sprendimų lęšį",
+      "pt": "executando a lente de decisão",
+      "it": "esecuzione della lente decisionale",
+      "no": "kjører beslutningslinsen",
+      "el": "εκτέλεση του φακού απόφασης"
+    },
     "common.messages.context_adding_intervention": {
       "en": "adding intervention",
       "es": "agregando intervención",

--- a/MarineSABRES_SES_Shiny/translations/modules/analysis_decision_lens.json
+++ b/MarineSABRES_SES_Shiny/translations/modules/analysis_decision_lens.json
@@ -1,0 +1,214 @@
+{
+  "languages": ["en", "es", "fr", "de", "lt", "pt", "it", "no", "el"],
+  "translation": {
+    "modules.analysis.decision_lens.title": {
+      "en": "Decision Lens",
+      "es": "Lente de decisión",
+      "fr": "Loupe de décision",
+      "de": "Entscheidungslinse",
+      "lt": "Sprendimų lęšis",
+      "pt": "Lente de decisão",
+      "it": "Lente decisionale",
+      "no": "Beslutningslinse",
+      "el": "Φακός απόφασης"
+    },
+    "modules.analysis.decision_lens.subtitle": {
+      "en": "Factor classification and why-it-matters interpretation",
+      "es": "Clasificación de factores e interpretación de su importancia",
+      "fr": "Classification des facteurs et interprétation de leur importance",
+      "de": "Faktorklassifizierung und Interpretation der Bedeutung",
+      "lt": "Veiksnių klasifikavimas ir reikšmės aiškinimas",
+      "pt": "Classificação de fatores e interpretação da sua importância",
+      "it": "Classificazione dei fattori e interpretazione della loro importanza",
+      "no": "Faktorklassifisering og tolkning av betydning",
+      "el": "Ταξινόμηση παραγόντων και ερμηνεία της σημασίας τους"
+    },
+    "modules.analysis.decision_lens.help_title": {
+      "en": "About the Decision Lens",
+      "es": "Acerca de la Lente de decisión",
+      "fr": "À propos de la Loupe de décision",
+      "de": "Über die Entscheidungslinse",
+      "lt": "Apie Sprendimų lęšį",
+      "pt": "Sobre a Lente de decisão",
+      "it": "Informazioni sulla Lente decisionale",
+      "no": "Om Beslutningslinsen",
+      "el": "Σχετικά με τον Φακό απόφασης"
+    },
+    "modules.analysis.decision_lens.tab_factors": {
+      "en": "Factor Classification",
+      "es": "Clasificación de factores",
+      "fr": "Classification des facteurs",
+      "de": "Faktorklassifizierung",
+      "lt": "Veiksnių klasifikavimas",
+      "pt": "Classificação de fatores",
+      "it": "Classificazione dei fattori",
+      "no": "Faktorklassifisering",
+      "el": "Ταξινόμηση παραγόντων"
+    },
+    "modules.analysis.decision_lens.tab_why": {
+      "en": "Why This Matters",
+      "es": "Por qué es importante",
+      "fr": "Pourquoi c'est important",
+      "de": "Warum das wichtig ist",
+      "lt": "Kodėl tai svarbu",
+      "pt": "Por que isto importa",
+      "it": "Perché è importante",
+      "no": "Hvorfor dette er viktig",
+      "el": "Γιατί έχει σημασία"
+    },
+    "modules.analysis.decision_lens.factors_intro": {
+      "en": "Classify each system element by its structural influence (control) versus dependence (exposure). This surfaces the impact-vs-control axis: which elements drive the system and which mainly respond to it. The reading is structural — connection polarity and strength are not used.",
+      "es": "Clasifica cada elemento del sistema según su influencia estructural (control) frente a su dependencia (exposición). Esto revela el eje impacto-control: qué elementos impulsan el sistema y cuáles responden principalmente a él. La lectura es estructural: no se utilizan la polaridad ni la fuerza de las conexiones.",
+      "fr": "Classez chaque élément du système selon son influence structurelle (contrôle) par rapport à sa dépendance (exposition). Cela fait apparaître l'axe impact-contrôle : quels éléments pilotent le système et lesquels y réagissent surtout. La lecture est structurelle — la polarité et la force des connexions ne sont pas utilisées.",
+      "de": "Klassifizieren Sie jedes Systemelement nach seinem strukturellen Einfluss (Kontrolle) gegenüber seiner Abhängigkeit (Exposition). Dies zeigt die Wirkungs-Kontroll-Achse: welche Elemente das System antreiben und welche überwiegend darauf reagieren. Die Lesart ist strukturell — Polarität und Stärke der Verbindungen werden nicht verwendet.",
+      "lt": "Klasifikuokite kiekvieną sistemos elementą pagal jo struktūrinę įtaką (kontrolę) ir priklausomybę (paveikumą). Taip atskleidžiama poveikio ir kontrolės ašis: kurie elementai valdo sistemą, o kurie daugiausia į ją reaguoja. Vertinimas yra struktūrinis — ryšių poliškumas ir stiprumas nenaudojami.",
+      "pt": "Classifique cada elemento do sistema pela sua influência estrutural (controlo) face à sua dependência (exposição). Isto revela o eixo impacto-controlo: que elementos impulsionam o sistema e quais respondem principalmente a ele. A leitura é estrutural — a polaridade e a força das ligações não são utilizadas.",
+      "it": "Classifica ogni elemento del sistema in base alla sua influenza strutturale (controllo) rispetto alla sua dipendenza (esposizione). Questo evidenzia l'asse impatto-controllo: quali elementi guidano il sistema e quali vi rispondono principalmente. La lettura è strutturale — la polarità e la forza delle connessioni non sono utilizzate.",
+      "no": "Klassifiser hvert systemelement etter dets strukturelle innflytelse (kontroll) mot dets avhengighet (eksponering). Dette viser virkning-mot-kontroll-aksen: hvilke elementer driver systemet og hvilke hovedsakelig reagerer på det. Lesningen er strukturell — koblingenes polaritet og styrke brukes ikke.",
+      "el": "Ταξινομήστε κάθε στοιχείο του συστήματος ανάλογα με τη δομική του επιρροή (έλεγχος) έναντι της εξάρτησής του (έκθεση). Αυτό αναδεικνύει τον άξονα επίδρασης-ελέγχου: ποια στοιχεία κινούν το σύστημα και ποια κυρίως αντιδρούν σε αυτό. Η ανάγνωση είναι δομική — η πολικότητα και η ισχύς των συνδέσεων δεν χρησιμοποιούνται."
+    },
+    "modules.analysis.decision_lens.factors_x_axis": {
+      "en": "Dependence (exposure to other elements)",
+      "es": "Dependencia (exposición a otros elementos)",
+      "fr": "Dépendance (exposition aux autres éléments)",
+      "de": "Abhängigkeit (Exposition gegenüber anderen Elementen)",
+      "lt": "Priklausomybė (paveikumas kitiems elementams)",
+      "pt": "Dependência (exposição a outros elementos)",
+      "it": "Dipendenza (esposizione ad altri elementi)",
+      "no": "Avhengighet (eksponering for andre elementer)",
+      "el": "Εξάρτηση (έκθεση σε άλλα στοιχεία)"
+    },
+    "modules.analysis.decision_lens.factors_y_axis": {
+      "en": "Influence (effect on other elements)",
+      "es": "Influencia (efecto sobre otros elementos)",
+      "fr": "Influence (effet sur les autres éléments)",
+      "de": "Einfluss (Wirkung auf andere Elemente)",
+      "lt": "Įtaka (poveikis kitiems elementams)",
+      "pt": "Influência (efeito sobre outros elementos)",
+      "it": "Influenza (effetto su altri elementi)",
+      "no": "Innflytelse (effekt på andre elementer)",
+      "el": "Επιρροή (επίδραση σε άλλα στοιχεία)"
+    },
+    "modules.analysis.decision_lens.quad_influential": {
+      "en": "High influence, low dependence — structurally upstream; a candidate lever worth prioritising for investigation. (Structural only: polarity and strength are ignored.)",
+      "es": "Alta influencia, baja dependencia: estructuralmente aguas arriba; una palanca candidata que conviene priorizar para su estudio. (Solo estructural: se ignoran la polaridad y la fuerza.)",
+      "fr": "Forte influence, faible dépendance — structurellement en amont ; un levier candidat à prioriser pour l'analyse. (Structurel uniquement : la polarité et la force sont ignorées.)",
+      "de": "Hoher Einfluss, geringe Abhängigkeit — strukturell vorgelagert; ein zu priorisierender Hebelkandidat. (Nur strukturell: Polarität und Stärke werden ignoriert.)",
+      "lt": "Didelė įtaka, maža priklausomybė — struktūriškai aukštupyje; svertas kandidatas, kurį verta tirti pirmiausia. (Tik struktūriškai: poliškumas ir stiprumas nevertinami.)",
+      "pt": "Alta influência, baixa dependência — estruturalmente a montante; uma alavanca candidata a priorizar para investigação. (Apenas estrutural: polaridade e força são ignoradas.)",
+      "it": "Alta influenza, bassa dipendenza — strutturalmente a monte; una leva candidata da prioritizzare per l'analisi. (Solo strutturale: polarità e forza sono ignorate.)",
+      "no": "Høy innflytelse, lav avhengighet — strukturelt oppstrøms; en kandidat-spak verdt å prioritere for undersøkelse. (Kun strukturelt: polaritet og styrke ignoreres.)",
+      "el": "Υψηλή επιρροή, χαμηλή εξάρτηση — δομικά ανάντη· υποψήφιος μοχλός που αξίζει να προτεραιοποιηθεί για διερεύνηση. (Μόνο δομικά: η πολικότητα και η ισχύς αγνοούνται.)"
+    },
+    "modules.analysis.decision_lens.quad_relay": {
+      "en": "High influence and high dependence — structurally central; changes here tend to propagate, so monitor knock-on effects. (Structural only.)",
+      "es": "Alta influencia y alta dependencia: estructuralmente central; los cambios aquí tienden a propagarse, así que vigile los efectos en cadena. (Solo estructural.)",
+      "fr": "Forte influence et forte dépendance — structurellement central ; les changements tendent à s'y propager, surveillez les effets en cascade. (Structurel uniquement.)",
+      "de": "Hoher Einfluss und hohe Abhängigkeit — strukturell zentral; Änderungen breiten sich hier tendenziell aus, beobachten Sie Folgewirkungen. (Nur strukturell.)",
+      "lt": "Didelė įtaka ir didelė priklausomybė — struktūriškai centrinis; pokyčiai čia linkę plisti, todėl stebėkite šalutinį poveikį. (Tik struktūriškai.)",
+      "pt": "Alta influência e alta dependência — estruturalmente central; as mudanças aqui tendem a propagar-se, por isso monitorize os efeitos em cadeia. (Apenas estrutural.)",
+      "it": "Alta influenza e alta dipendenza — strutturalmente centrale; i cambiamenti qui tendono a propagarsi, quindi monitora gli effetti a catena. (Solo strutturale.)",
+      "no": "Høy innflytelse og høy avhengighet — strukturelt sentral; endringer her har en tendens til å forplante seg, så overvåk ringvirkninger. (Kun strukturelt.)",
+      "el": "Υψηλή επιρροή και υψηλή εξάρτηση — δομικά κεντρικό· οι αλλαγές εδώ τείνουν να διαδίδονται, οπότε παρακολουθήστε τις αλυσιδωτές επιδράσεις. (Μόνο δομικά.)"
+    },
+    "modules.analysis.decision_lens.quad_dependent": {
+      "en": "Low influence, high dependence — structurally downstream; often a good outcome indicator, though it can still be a valid target for a restoration response. (Structural only.)",
+      "es": "Baja influencia, alta dependencia: estructuralmente aguas abajo; suele ser un buen indicador de resultados, aunque puede seguir siendo un objetivo válido para una respuesta de restauración. (Solo estructural.)",
+      "fr": "Faible influence, forte dépendance — structurellement en aval ; souvent un bon indicateur de résultat, bien qu'il puisse rester une cible valable pour une réponse de restauration. (Structurel uniquement.)",
+      "de": "Geringer Einfluss, hohe Abhängigkeit — strukturell nachgelagert; oft ein guter Ergebnisindikator, kann aber dennoch ein gültiges Ziel für eine Wiederherstellungsmaßnahme sein. (Nur strukturell.)",
+      "lt": "Maža įtaka, didelė priklausomybė — struktūriškai žemupyje; dažnai geras rezultato rodiklis, tačiau vis tiek gali būti tinkamas atkūrimo atsako objektas. (Tik struktūriškai.)",
+      "pt": "Baixa influência, alta dependência — estruturalmente a jusante; muitas vezes um bom indicador de resultado, embora possa ainda ser um alvo válido para uma resposta de restauro. (Apenas estrutural.)",
+      "it": "Bassa influenza, alta dipendenza — strutturalmente a valle; spesso un buon indicatore di risultato, anche se può restare un obiettivo valido per una risposta di ripristino. (Solo strutturale.)",
+      "no": "Lav innflytelse, høy avhengighet — strukturelt nedstrøms; ofte en god resultatindikator, men kan fortsatt være et gyldig mål for et gjenopprettingstiltak. (Kun strukturelt.)",
+      "el": "Χαμηλή επιρροή, υψηλή εξάρτηση — δομικά κατάντη· συχνά καλός δείκτης αποτελέσματος, αν και μπορεί να παραμένει έγκυρος στόχος για μια απόκριση αποκατάστασης. (Μόνο δομικά.)"
+    },
+    "modules.analysis.decision_lens.quad_autonomous": {
+      "en": "Low influence and low dependence — weakly coupled; typically lower priority. (Structural only.)",
+      "es": "Baja influencia y baja dependencia: débilmente acoplado; normalmente de menor prioridad. (Solo estructural.)",
+      "fr": "Faible influence et faible dépendance — faiblement couplé ; généralement moins prioritaire. (Structurel uniquement.)",
+      "de": "Geringer Einfluss und geringe Abhängigkeit — schwach gekoppelt; in der Regel niedrigere Priorität. (Nur strukturell.)",
+      "lt": "Maža įtaka ir maža priklausomybė — silpnai susijęs; paprastai žemesnio prioriteto. (Tik struktūriškai.)",
+      "pt": "Baixa influência e baixa dependência — fracamente acoplado; normalmente de menor prioridade. (Apenas estrutural.)",
+      "it": "Bassa influenza e bassa dipendenza — debolmente accoppiato; in genere a priorità inferiore. (Solo strutturale.)",
+      "no": "Lav innflytelse og lav avhengighet — svakt koblet; vanligvis lavere prioritet. (Kun strukturelt.)",
+      "el": "Χαμηλή επιρροή και χαμηλή εξάρτηση — ασθενώς συζευγμένο· συνήθως χαμηλότερης προτεραιότητας. (Μόνο δομικά.)"
+    },
+    "modules.analysis.decision_lens.why_intro": {
+      "en": "Select an element to see a plain-language reading of its structural role and loop participation.",
+      "es": "Seleccione un elemento para ver una lectura en lenguaje sencillo de su papel estructural y su participación en bucles.",
+      "fr": "Sélectionnez un élément pour obtenir une lecture en langage clair de son rôle structurel et de sa participation aux boucles.",
+      "de": "Wählen Sie ein Element, um eine verständliche Beschreibung seiner strukturellen Rolle und Schleifenbeteiligung zu sehen.",
+      "lt": "Pasirinkite elementą, kad pamatytumėte aiškų jo struktūrinio vaidmens ir dalyvavimo cikluose aprašymą.",
+      "pt": "Selecione um elemento para ver uma leitura em linguagem simples do seu papel estrutural e participação em ciclos.",
+      "it": "Seleziona un elemento per vedere una lettura in linguaggio semplice del suo ruolo strutturale e della partecipazione ai cicli.",
+      "no": "Velg et element for å se en lettfattelig beskrivelse av dets strukturelle rolle og sløyfedeltakelse.",
+      "el": "Επιλέξτε ένα στοιχείο για να δείτε μια απλή περιγραφή του δομικού του ρόλου και της συμμετοχής του σε βρόχους."
+    },
+    "modules.analysis.decision_lens.narrative_in_loops": {
+      "en": "Participates in %d reinforcing and %d balancing loop(s).",
+      "es": "Participa en %d bucle(s) de refuerzo y %d de equilibrio.",
+      "fr": "Participe à %d boucle(s) de renforcement et %d d'équilibrage.",
+      "de": "Beteiligt an %d verstärkenden und %d ausgleichenden Schleifen.",
+      "lt": "Dalyvauja %d stiprinančiame (-iuose) ir %d balansuojančiame (-iuose) cikle (-uose).",
+      "pt": "Participa em %d ciclo(s) de reforço e %d de equilíbrio.",
+      "it": "Partecipa a %d ciclo/i di rinforzo e %d di bilanciamento.",
+      "no": "Deltar i %d forsterkende og %d balanserende sløyfe(r).",
+      "el": "Συμμετέχει σε %d ενισχυτικό(ούς) και %d εξισορροπητικό(ούς) βρόχο(ους)."
+    },
+    "modules.analysis.decision_lens.narrative_archetype_leverage": {
+      "en": "Possible leverage point for the archetype",
+      "es": "Posible punto de apalancamiento para el arquetipo",
+      "fr": "Point de levier possible pour l'archétype",
+      "de": "Möglicher Hebelpunkt für das Archetyp-Muster",
+      "lt": "Galimas sverto taškas archetipui",
+      "pt": "Possível ponto de alavancagem para o arquétipo",
+      "it": "Possibile punto di leva per l'archetipo",
+      "no": "Mulig brekkstangspunkt for arketypen",
+      "el": "Πιθανό σημείο μόχλευσης για το αρχέτυπο"
+    },
+    "modules.analysis.decision_lens.narrative_confirm": {
+      "en": "Candidate interpretation — confirm with stakeholders before acting.",
+      "es": "Interpretación candidata: confírmela con las partes interesadas antes de actuar.",
+      "fr": "Interprétation candidate — à confirmer avec les parties prenantes avant d'agir.",
+      "de": "Kandidaten-Interpretation — vor dem Handeln mit den Beteiligten bestätigen.",
+      "lt": "Galima interpretacija — prieš veikdami patvirtinkite su suinteresuotosiomis šalimis.",
+      "pt": "Interpretação candidata — confirme com as partes interessadas antes de agir.",
+      "it": "Interpretazione candidata — confermare con le parti interessate prima di agire.",
+      "no": "Kandidattolkning — bekreft med interessenter før du handler.",
+      "el": "Υποψήφια ερμηνεία — επιβεβαιώστε με τους εμπλεκόμενους πριν ενεργήσετε."
+    },
+    "modules.analysis.decision_lens.btn_analyze": {
+      "en": "Analyse",
+      "es": "Analizar",
+      "fr": "Analyser",
+      "de": "Analysieren",
+      "lt": "Analizuoti",
+      "pt": "Analisar",
+      "it": "Analizza",
+      "no": "Analyser",
+      "el": "Ανάλυση"
+    },
+    "modules.analysis.decision_lens.no_network_data": {
+      "en": "No network data available. Build or load a CLD first.",
+      "es": "No hay datos de red disponibles. Cree o cargue primero un DCB.",
+      "fr": "Aucune donnée de réseau disponible. Créez ou chargez d'abord un diagramme causal.",
+      "de": "Keine Netzwerkdaten verfügbar. Erstellen oder laden Sie zuerst ein Kausaldiagramm.",
+      "lt": "Tinklo duomenų nėra. Pirmiausia sukurkite arba įkelkite priežastinį ciklų diagramą.",
+      "pt": "Sem dados de rede disponíveis. Crie ou carregue primeiro um DCB.",
+      "it": "Nessun dato di rete disponibile. Crea o carica prima un diagramma causale.",
+      "no": "Ingen nettverksdata tilgjengelig. Bygg eller last inn et CLD først.",
+      "el": "Δεν υπάρχουν διαθέσιμα δεδομένα δικτύου. Δημιουργήστε ή φορτώστε πρώτα ένα CLD."
+    },
+    "modules.analysis.decision_lens.click_analyze": {
+      "en": "Click Analyse to classify system factors.",
+      "es": "Haga clic en Analizar para clasificar los factores del sistema.",
+      "fr": "Cliquez sur Analyser pour classer les facteurs du système.",
+      "de": "Klicken Sie auf Analysieren, um die Systemfaktoren zu klassifizieren.",
+      "lt": "Spustelėkite Analizuoti, kad klasifikuotumėte sistemos veiksnius.",
+      "pt": "Clique em Analisar para classificar os fatores do sistema.",
+      "it": "Fai clic su Analizza per classificare i fattori del sistema.",
+      "no": "Klikk Analyser for å klassifisere systemfaktorene.",
+      "el": "Κάντε κλικ στην Ανάλυση για να ταξινομήσετε τους παράγοντες του συστήματος."
+    }
+  }
+}

--- a/MarineSABRES_SES_Shiny/translations/ui/sidebar.json
+++ b/MarineSABRES_SES_Shiny/translations/ui/sidebar.json
@@ -143,6 +143,17 @@
       "no": "Påvirkningspunktanalyse",
       "el": "Ανάλυση Σημείων Μόχλευσης"
     },
+    "ui.sidebar.decision_lens": {
+      "en": "Decision Lens",
+      "es": "Lente de decisión",
+      "fr": "Loupe de décision",
+      "de": "Entscheidungslinse",
+      "lt": "Sprendimų lęšis",
+      "pt": "Lente de decisão",
+      "it": "Lente decisionale",
+      "no": "Beslutningslinse",
+      "el": "Φακός απόφασης"
+    },
     "ui.sidebar.load_a_previously_saved_project": {
       "en": "Load a previously saved project",
       "es": "Cargar un proyecto guardado anteriormente",
@@ -516,6 +527,17 @@
       "it": "Identifica punti di intervento ad alta leva combinando metriche di centralità e partecipazione ai cicli per trovare nodi dove piccoli cambiamenti possono avere grandi effetti sull'intero sistema",
       "no": "Identifiser høye påvirkningspunkter for intervensjon ved å kombinere sentralitetsmålinger og sløyfedeltakelse for å finne noder der små endringer kan ha store systemomfattende effekter",
       "el": "Εντοπίστε σημεία παρέμβασης υψηλής μόχλευσης συνδυάζοντας μετρικές κεντρικότητας και συμμετοχή σε βρόχους για να βρείτε κόμβους όπου μικρές αλλαγές μπορούν να έχουν μεγάλες επιπτώσεις σε ολόκληρο το σύστημα"
+    },
+    "ui.sidebar.tooltip.decision_lens": {
+      "en": "Classify elements by influence vs dependence (the impact-control axis) and read why each matters — a structural, QSEM-inspired interpretation layer",
+      "es": "Clasifique los elementos por influencia frente a dependencia (el eje impacto-control) y comprenda por qué importa cada uno: una capa de interpretación estructural inspirada en QSEM",
+      "fr": "Classez les éléments par influence vs dépendance (l'axe impact-contrôle) et comprenez pourquoi chacun compte — une couche d'interprétation structurelle inspirée de QSEM",
+      "de": "Klassifizieren Sie Elemente nach Einfluss vs. Abhängigkeit (die Wirkungs-Kontroll-Achse) und verstehen Sie, warum jedes wichtig ist — eine strukturelle, von QSEM inspirierte Interpretationsebene",
+      "lt": "Klasifikuokite elementus pagal įtaką ir priklausomybę (poveikio ir kontrolės ašis) ir supraskite, kodėl kiekvienas svarbus — struktūrinis, QSEM įkvėptas aiškinimo sluoksnis",
+      "pt": "Classifique os elementos por influência vs dependência (o eixo impacto-controlo) e compreenda por que cada um importa — uma camada de interpretação estrutural inspirada no QSEM",
+      "it": "Classifica gli elementi per influenza vs dipendenza (l'asse impatto-controllo) e comprendi perché ciascuno è importante — un livello di interpretazione strutturale ispirato a QSEM",
+      "no": "Klassifiser elementer etter innflytelse mot avhengighet (virkning-kontroll-aksen) og forstå hvorfor hvert er viktig — et strukturelt, QSEM-inspirert tolkningslag",
+      "el": "Ταξινομήστε τα στοιχεία ανά επιρροή έναντι εξάρτησης (ο άξονας επίδρασης-ελέγχου) και κατανοήστε γιατί έχει σημασία το καθένα — ένα δομικό επίπεδο ερμηνείας εμπνευσμένο από το QSEM"
     },
     "ui.sidebar.tooltip.bot_analysis": {
       "en": "Balance Over Time (BOT) analysis identifies structural patterns that may lead to policy resistance, unintended consequences, or system delays requiring careful intervention design",


### PR DESCRIPTION
## Summary

Adds a new **Decision Lens** analysis module — a QSEM-inspired interpretation layer
that surfaces the toolbox's **dormant MICMAC analysis** (`calculate_micmac_safe`, which
was defined and tested but never wired into any UI) as an **influence-vs-dependence
quadrant** (the impact-vs-control axis), plus a deterministic, i18n-templated
**"why this matters"** narrative per element.

This is **Phase 1** of a larger design (see local spec/plan under `docs/superpowers/`,
gitignored). It deliberately ships the analytically-sound half and **defers** the
archetype-detection half — see "Deferred" below.

## What's included
- `functions/decision_lens.R` — pure, unit-tested helpers:
  - `classify_factors_micmac()` — labelled, display-ready MICMAC table
  - `build_decision_narrative()` — deterministic, i18n-templated narrative (never ML;
    torch is optional and would blank out on light deployments)
  - `dl_code_from_id()` — derives the DAPSIWRM code from the prefixed node id (language-proof)
- `modules/analysis_decision_lens.R` — Factor Classification + Why-This-Matters tabs;
  quadrant scatter **dual-encoded (colour + shape)** for accessibility
- Wiring: `app.R` (module list / tab / server), full sidebar branch, `global.R` source
- Translations across **all 9 languages** (module keys + sidebar label/tooltip + error
  context). Machine-drafted — **native-speaker review pending** (project precedent).
- Cross-tool "next steps" links (reuse existing i18n keys, no new copy)
- Tests: `test-decision-lens.R` (19) + `test-analysis-decision-lens-module.R` (5)

## Verification
Green locally: decision-lens unit **19**, module signature **5**, i18n enforcement **89**,
source-chain invariant **8** — all `FAIL 0`. (Full suite run was in progress at PR time;
result will be noted in a comment.)

## Built from an adversarial review (revise-first)
A 6-angle workflow review (51 agents, 44 findings, 43 verified) caught a **blocking
data-model error** before any archetype code shipped: `nodes$group` holds **full category
names** (`"Drivers"`, `"Marine Processes & Functioning"`…) with **prefixed ids**
(`D_1`, `MPF_3`) — not the short codes the original archetype rules assumed (verified
against `functions/visnetwork_helpers.R`). It also flagged **harmful leverage advice**
("intensify the Pressure"). Both are fixed in the spec/plan; the MICMAC narrative was
softened to **structural** language (no dynamical-stability overclaims).

## Deferred (by design — not in this PR)
- **Archetype detection** ("leverage-point explanation" half) — needs re-derivation
  against **valid** DAPSIWRM loop topology (the framework forbids e.g. State→Activity, so
  the naive commons/limits loops never survive `validate_dapsirwrm`) **and** must pass the
  `scientific-validation` skill before build.
- `testServer` behaviour test with a real `isa_data` fixture (signature test covers the
  contract for now).
- Native-speaker translation review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Decision Lens analysis tool to understand factor importance and system impact.
  * Includes factor classification view analyzing influence and control relationships.
  * Provides narrative explanations of why specific factors matter in your system.
  * Full multilingual support across all supported languages.

* **Tests**
  * Added comprehensive test coverage for the new Decision Lens module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->