### PR TITLE
feat(decision-lens): system-archetype detection (Commons + Limits to Growth)

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/decision_lens.R
+++ b/MarineSABRES_SES_Shiny/functions/decision_lens.R
@@ -67,6 +67,102 @@ classify_factors_micmac <- function(nodes, edges) {
   trimws(strsplit(node_ids_str, ",")[[1]])
 }
 
+#' Detect candidate system archetypes from framework-valid loops
+#'
+#' Topology-correct, scientifically validated (2026-06-21; see spec §6/§6.1).
+#' DAPSIWRM-valid cycles close via either GB->D (reinforcing "engine") or a
+#' Response feedback R->{D,A,P,S} (balancing). This detects the two robust,
+#' structurally distinguishable motifs:
+#'   - Tragedy of the Commons: a shared State(MPF)/ES resource drawn on by >=2
+#'     distinct Activities across >=2 loops -> govern the shared resource.
+#'   - Limits to Growth: a Reinforcing engine (contains D/A) coupled to a
+#'     Response-mediated Balancing loop -> leverage the Response.
+#' Fixes-that-Fail and Shifting-the-Burden are intentionally NOT detected here
+#' (the former is not separable from Limits-to-Growth without delay/temporal
+#' data, which these CLDs lack; the latter has weak marine-SES support).
+#'
+#' All detections are candidates (confidence = "candidate") — confirm with
+#' stakeholders. Element type is derived from the id prefix (dl_code_from_id).
+#'
+#' @param loop_info data.frame with LoopID, Type ("Reinforcing"/"Balancing"), NodeIDs
+#' @param nodes optional; reserved for future use (types are derived from ids)
+#' @return list of archetype records, each a list with archetype_key, loop_ids,
+#'   node_ids, shared_node_ids, leverage_node_id, confidence. Empty list if none.
+#' @export
+detect_archetypes <- function(loop_info, nodes = NULL) {
+  out <- list()
+  if (is.null(loop_info) || nrow(loop_info) == 0) return(out)
+
+  loop_nodes <- lapply(seq_len(nrow(loop_info)), function(i) .dl_loop_nodes(loop_info$NodeIDs[i]))
+  loop_codes <- lapply(loop_nodes, dl_code_from_id)
+  types <- as.character(loop_info$Type)
+
+  # --- B. Tragedy of the Commons ----------------------------------------
+  # Shared MPF/ES node in >=2 loops whose union has >=2 distinct Activities.
+  # The common-pool resource is the shared State/stock, so PREFER MPF over ES,
+  # and report each distinct loop-set once (downstream ES/GB reconverge and
+  # would otherwise double-flag the same commons dynamic).
+  commons_nodes <- sort(unique(unlist(lapply(seq_along(loop_nodes), function(i) {
+    loop_nodes[[i]][loop_codes[[i]] %in% c("MPF", "ES")]
+  }))))
+  cand <- list()
+  for (res in commons_nodes) {
+    in_loops <- which(vapply(loop_nodes, function(s) res %in% s, logical(1)))
+    if (length(in_loops) < 2) next
+    activities <- unique(unlist(lapply(in_loops, function(i) {
+      loop_nodes[[i]][loop_codes[[i]] == "A"]
+    })))
+    if (length(activities) < 2) next
+    ids <- sort(loop_info$LoopID[in_loops])
+    cand[[length(cand) + 1]] <- list(
+      res = res, code = dl_code_from_id(res), in_loops = in_loops,
+      loopkey = paste(ids, collapse = ",")
+    )
+  }
+  # MPF candidates first, then ES; dedup by identical loop-set.
+  if (length(cand) > 0) {
+    cand <- cand[order(ifelse(vapply(cand, function(c) c$code, "") == "MPF", 0L, 1L))]
+    seen <- character(0)
+    for (c in cand) {
+      if (c$loopkey %in% seen) next
+      seen <- c(seen, c$loopkey)
+      out[[length(out) + 1]] <- list(
+        archetype_key    = "tragedy_of_the_commons",
+        loop_ids         = sort(loop_info$LoopID[c$in_loops]),
+        node_ids         = sort(unique(unlist(loop_nodes[c$in_loops]))),
+        shared_node_ids  = c$res,
+        leverage_node_id = c$res,
+        confidence       = "candidate"
+      )
+    }
+  }
+
+  # --- A. Limits to Growth ----------------------------------------------
+  # Reinforcing loop (engine; contains D or A) coupled (shares >=1 node) to a
+  # Balancing loop that contains a Response (R). Leverage = the Response.
+  rein <- which(types == "Reinforcing")
+  bal  <- which(types == "Balancing")
+  for (ri in rein) {
+    if (!any(loop_codes[[ri]] %in% c("D", "A"))) next
+    for (bi in bal) {
+      r_in_bal <- loop_nodes[[bi]][loop_codes[[bi]] == "R"]
+      if (length(r_in_bal) == 0) next
+      shared <- intersect(loop_nodes[[ri]], loop_nodes[[bi]])
+      if (length(shared) == 0) next
+      out[[length(out) + 1]] <- list(
+        archetype_key    = "limits_to_growth",
+        loop_ids         = c(loop_info$LoopID[ri], loop_info$LoopID[bi]),
+        node_ids         = sort(unique(c(loop_nodes[[ri]], loop_nodes[[bi]]))),
+        shared_node_ids  = sort(shared),
+        leverage_node_id = r_in_bal[1],   # the management Response (deterministic: first in loop order)
+        confidence       = "candidate"
+      )
+    }
+  }
+
+  out
+}
+
 #' Build a deterministic "why this matters" narrative for one node
 #'
 #' Fuses the node's MICMAC quadrant role, loop participation, and (when the

--- a/MarineSABRES_SES_Shiny/modules/analysis_decision_lens.R
+++ b/MarineSABRES_SES_Shiny/modules/analysis_decision_lens.R
@@ -32,7 +32,15 @@ analysis_decision_lens_ui <- function(id, i18n) {
           DT::dataTableOutput(ns("factors_table"))
         ),
 
-        # Tab 2: Why This Matters ----
+        # Tab 2: System Archetypes ----
+        tabPanel(i18n$t("modules.analysis.decision_lens.tab_archetypes"),
+          div(class = "alert alert-info",
+              icon("info-circle"), " ",
+              i18n$t("modules.analysis.decision_lens.archetype_candidate_caveat")),
+          uiOutput(ns("archetypes_ui"))
+        ),
+
+        # Tab 3: Why This Matters ----
         tabPanel(i18n$t("modules.analysis.decision_lens.tab_why"),
           p(i18n$t("modules.analysis.decision_lens.why_intro")),
           selectInput(ns("why_node"), NULL, choices = NULL),
@@ -47,7 +55,7 @@ analysis_decision_lens_ui <- function(id, i18n) {
 analysis_decision_lens_server <- function(id, project_data_reactive, i18n, event_bus = NULL) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
-    rv <- reactiveValues(factors = NULL, loop_info = NULL)
+    rv <- reactiveValues(factors = NULL, loop_info = NULL, archetypes = NULL)
 
     # Stale-data observer
     observe({
@@ -100,6 +108,7 @@ analysis_decision_lens_server <- function(id, project_data_reactive, i18n, event
         loops <- find_all_cycles(g$nodes, g$edges, max_length = 8, max_cycles = 500,
                                  timeout_seconds = LOOP_ANALYSIS_TIMEOUT_SECONDS)
         rv$loop_info <- process_cycles_to_loops(loops, g$nodes, g$edges, gph)
+        rv$archetypes <- detect_archetypes(rv$loop_info, g$nodes)
 
         updateSelectInput(session, "why_node",
                           choices = setNames(rv$factors$id, rv$factors$label))
@@ -139,10 +148,37 @@ analysis_decision_lens_server <- function(id, project_data_reactive, i18n, event
                     rownames = FALSE)
     })
 
+    output$archetypes_ui <- renderUI({
+      req(!is.null(rv$archetypes))
+      if (length(rv$archetypes) == 0) {
+        return(div(class = "alert alert-secondary",
+                   i18n$t("modules.analysis.decision_lens.archetypes_none")))
+      }
+      label_of <- function(id) {
+        m <- rv$factors$label[match(id, rv$factors$id)]
+        if (length(m) == 0 || is.na(m)) id else m
+      }
+      tagList(
+        p(i18n$t("modules.analysis.decision_lens.archetypes_intro")),
+        lapply(rv$archetypes, function(a) {
+          k <- paste0("modules.analysis.decision_lens.archetype.", a$archetype_key)
+          wellPanel(
+            h4(i18n$t(paste0(k, ".name"))),
+            p(i18n$t(paste0(k, ".desc"))),
+            p(strong(i18n$t("modules.analysis.decision_lens.narrative_archetype_leverage")), ": ",
+              label_of(a$leverage_node_id)),
+            p(em(i18n$t(paste0(k, ".leverage")))),
+            tags$small(class = "text-muted",
+                       paste0("Loops: ", paste(a$loop_ids, collapse = ", ")))
+          )
+        })
+      )
+    })
+
     output$why_narrative <- renderUI({
       req(input$why_node, rv$factors)
       HTML(build_decision_narrative(input$why_node, rv$factors, rv$loop_info,
-                                    archetypes = list(), i18n))  # archetypes deferred
+                                    rv$archetypes %||% list(), i18n))
     })
 
     output$next_steps_ui <- renderUI({

--- a/MarineSABRES_SES_Shiny/tests/testthat/test-decision-lens.R
+++ b/MarineSABRES_SES_Shiny/tests/testthat/test-decision-lens.R
@@ -105,3 +105,60 @@ test_that("build_decision_narrative omits archetype line when archetypes is empt
   expect_match(html, "modules.analysis.decision_lens.narrative_confirm", fixed = TRUE)
   expect_false(grepl("narrative_archetype_leverage", html, fixed = TRUE))
 })
+
+# ---------------------------------------------------------------------------
+# detect_archetypes — topology-correct (validated 2026-06-21). Ships B + A only.
+# Fixtures use real create_nodes_df-style ids (D_1, MPF_1, R_1, ...).
+# ---------------------------------------------------------------------------
+test_that("detect_archetypes finds Tragedy of the Commons: shared MPF in >=2 loops, >=2 distinct Activities", {
+  # Two activity loops sharing the State/MPF resource, each closing via GB->D->A
+  loop_info <- data.frame(
+    LoopID  = c(1L, 2L),
+    Type    = c("Reinforcing", "Reinforcing"),
+    NodeIDs = c("D_1,A_1,P_1,MPF_1,ES_1,GB_1",
+                "D_1,A_2,P_2,MPF_1,ES_1,GB_1"),
+    stringsAsFactors = FALSE
+  )
+  res <- detect_archetypes(loop_info)
+  keys <- vapply(res, function(x) x$archetype_key, character(1))
+  expect_true("tragedy_of_the_commons" %in% keys)
+  toc <- res[[which(keys == "tragedy_of_the_commons")[1]]]
+  expect_equal(toc$leverage_node_id, "MPF_1")       # govern the shared resource
+  expect_setequal(toc$loop_ids, c(1L, 2L))
+  expect_equal(toc$confidence, "candidate")
+})
+
+test_that("detect_archetypes does NOT fire Commons with only one Activity across the loops", {
+  loop_info <- data.frame(
+    LoopID  = c(1L, 2L),
+    Type    = c("Reinforcing", "Balancing"),
+    NodeIDs = c("D_1,A_1,P_1,MPF_1,ES_1,GB_1",
+                "GB_1,R_1,MPF_1,ES_1"),     # second loop has no distinct second Activity
+    stringsAsFactors = FALSE
+  )
+  res <- detect_archetypes(loop_info)
+  keys <- vapply(res, function(x) x$archetype_key, character(1))
+  expect_false("tragedy_of_the_commons" %in% keys)
+})
+
+test_that("detect_archetypes finds Limits to Growth: reinforcing engine coupled to Response-mediated balancing loop", {
+  loop_info <- data.frame(
+    LoopID  = c(1L, 2L),
+    Type    = c("Reinforcing", "Balancing"),
+    # engine (GB->D closed) shares GB_1/ES_1/MPF_1 with the Response-mediated balancing loop
+    NodeIDs = c("D_1,A_1,P_1,MPF_1,ES_1,GB_1",
+                "GB_1,R_1,P_1,MPF_1,ES_1"),
+    stringsAsFactors = FALSE
+  )
+  res <- detect_archetypes(loop_info)
+  keys <- vapply(res, function(x) x$archetype_key, character(1))
+  expect_true("limits_to_growth" %in% keys)
+  ltg <- res[[which(keys == "limits_to_growth")[1]]]
+  expect_equal(ltg$leverage_node_id, "R_1")          # the management Response, NOT the Pressure
+  expect_setequal(ltg$loop_ids, c(1L, 2L))
+})
+
+test_that("detect_archetypes returns empty list when there are no loops", {
+  expect_equal(detect_archetypes(data.frame()), list())
+  expect_equal(detect_archetypes(NULL), list())
+})

--- a/MarineSABRES_SES_Shiny/translations/modules/analysis_decision_lens.json
+++ b/MarineSABRES_SES_Shiny/translations/modules/analysis_decision_lens.json
@@ -209,6 +209,116 @@
       "it": "Fai clic su Analizza per classificare i fattori del sistema.",
       "no": "Klikk Analyser for å klassifisere systemfaktorene.",
       "el": "Κάντε κλικ στην Ανάλυση για να ταξινομήσετε τους παράγοντες του συστήματος."
+    },
+    "modules.analysis.decision_lens.tab_archetypes": {
+      "en": "System Archetypes",
+      "es": "Arquetipos del sistema",
+      "fr": "Archétypes du système",
+      "de": "System-Archetypen",
+      "lt": "Sistemos archetipai",
+      "pt": "Arquétipos do sistema",
+      "it": "Archetipi del sistema",
+      "no": "Systemarketyper",
+      "el": "Αρχέτυπα συστήματος"
+    },
+    "modules.analysis.decision_lens.archetypes_intro": {
+      "en": "Candidate system archetypes detected from the feedback-loop structure. Each is a possible pattern to confirm with stakeholders — not an assertion.",
+      "es": "Arquetipos del sistema candidatos detectados a partir de la estructura de bucles de retroalimentación. Cada uno es un patrón posible que debe confirmarse con las partes interesadas, no una afirmación.",
+      "fr": "Archétypes du système candidats détectés à partir de la structure des boucles de rétroaction. Chacun est un schéma possible à confirmer avec les parties prenantes — pas une affirmation.",
+      "de": "Kandidaten-Systemarchetypen, erkannt aus der Rückkopplungsschleifen-Struktur. Jeder ist ein mögliches Muster, das mit den Beteiligten zu bestätigen ist — keine Behauptung.",
+      "lt": "Galimi sistemos archetipai, aptikti iš grįžtamojo ryšio ciklų struktūros. Kiekvienas yra galimas modelis, kurį reikia patvirtinti su suinteresuotosiomis šalimis, o ne teiginys.",
+      "pt": "Arquétipos do sistema candidatos detetados a partir da estrutura de ciclos de retroalimentação. Cada um é um padrão possível a confirmar com as partes interessadas — não uma afirmação.",
+      "it": "Archetipi di sistema candidati rilevati dalla struttura dei cicli di retroazione. Ciascuno è un possibile schema da confermare con le parti interessate — non un'affermazione.",
+      "no": "Kandidat-systemarketyper oppdaget fra tilbakekoblingssløyfe-strukturen. Hver er et mulig mønster som må bekreftes med interessenter — ikke en påstand.",
+      "el": "Υποψήφια αρχέτυπα συστήματος που εντοπίστηκαν από τη δομή των βρόχων ανάδρασης. Καθένα είναι ένα πιθανό μοτίβο προς επιβεβαίωση με τους εμπλεκόμενους — όχι ισχυρισμός."
+    },
+    "modules.analysis.decision_lens.archetypes_none": {
+      "en": "No candidate archetypes detected in the current loop structure.",
+      "es": "No se han detectado arquetipos candidatos en la estructura de bucles actual.",
+      "fr": "Aucun archétype candidat détecté dans la structure de boucles actuelle.",
+      "de": "Keine Kandidaten-Archetypen in der aktuellen Schleifenstruktur erkannt.",
+      "lt": "Dabartinėje ciklų struktūroje galimų archetipų neaptikta.",
+      "pt": "Não foram detetados arquétipos candidatos na estrutura de ciclos atual.",
+      "it": "Nessun archetipo candidato rilevato nell'attuale struttura dei cicli.",
+      "no": "Ingen kandidat-arketyper oppdaget i den nåværende sløyfestrukturen.",
+      "el": "Δεν εντοπίστηκαν υποψήφια αρχέτυπα στην τρέχουσα δομή βρόχων."
+    },
+    "modules.analysis.decision_lens.archetype_candidate_caveat": {
+      "en": "These are structural candidates from causal-loop patterns — confirm with stakeholders before acting on any leverage point.",
+      "es": "Estos son candidatos estructurales a partir de patrones de bucles causales: confírmelos con las partes interesadas antes de actuar sobre cualquier punto de apalancamiento.",
+      "fr": "Ce sont des candidats structurels issus de schémas de boucles causales — à confirmer avec les parties prenantes avant d'agir sur un point de levier.",
+      "de": "Dies sind strukturelle Kandidaten aus Kausalschleifen-Mustern — vor dem Handeln an einem Hebelpunkt mit den Beteiligten bestätigen.",
+      "lt": "Tai struktūriniai kandidatai iš priežastinių ciklų modelių — prieš veikdami su bet kuriuo sverto tašku, patvirtinkite su suinteresuotosiomis šalimis.",
+      "pt": "Estes são candidatos estruturais a partir de padrões de ciclos causais — confirme com as partes interessadas antes de agir sobre qualquer ponto de alavancagem.",
+      "it": "Questi sono candidati strutturali da schemi di cicli causali — confermare con le parti interessate prima di agire su qualsiasi punto di leva.",
+      "no": "Dette er strukturelle kandidater fra årsakssløyfemønstre — bekreft med interessenter før du handler på et brekkstangspunkt.",
+      "el": "Πρόκειται για δομικούς υποψηφίους από μοτίβα αιτιωδών βρόχων — επιβεβαιώστε με τους εμπλεκόμενους πριν ενεργήσετε σε οποιοδήποτε σημείο μόχλευσης."
+    },
+    "modules.analysis.decision_lens.archetype.tragedy_of_the_commons.name": {
+      "en": "Tragedy of the Commons",
+      "es": "Tragedia de los comunes",
+      "fr": "Tragédie des biens communs",
+      "de": "Tragik der Allmende",
+      "lt": "Bendrų išteklių tragedija",
+      "pt": "Tragédia dos comuns",
+      "it": "Tragedia dei beni comuni",
+      "no": "Allmenningens tragedie",
+      "el": "Τραγωδία των κοινών"
+    },
+    "modules.analysis.decision_lens.archetype.tragedy_of_the_commons.desc": {
+      "en": "Several activities draw on the same shared resource, each loop reinforcing its own use until the resource is degraded for all.",
+      "es": "Varias actividades utilizan el mismo recurso compartido, cada bucle reforzando su propio uso hasta que el recurso se degrada para todos.",
+      "fr": "Plusieurs activités puisent dans la même ressource partagée, chaque boucle renforçant son propre usage jusqu'à la dégradation de la ressource pour tous.",
+      "de": "Mehrere Aktivitäten nutzen dieselbe gemeinsame Ressource, jede Schleife verstärkt ihre eigene Nutzung, bis die Ressource für alle verschlechtert ist.",
+      "lt": "Kelios veiklos naudoja tą patį bendrą išteklių, kiekvienas ciklas stiprina savo naudojimą, kol išteklius degraduoja visiems.",
+      "pt": "Várias atividades utilizam o mesmo recurso partilhado, cada ciclo reforçando o seu próprio uso até o recurso se degradar para todos.",
+      "it": "Diverse attività attingono alla stessa risorsa condivisa, ogni ciclo rafforzando il proprio uso finché la risorsa si degrada per tutti.",
+      "no": "Flere aktiviteter trekker på den samme delte ressursen, hver sløyfe forsterker sin egen bruk til ressursen forringes for alle.",
+      "el": "Πολλές δραστηριότητες αντλούν από τον ίδιο κοινό πόρο, κάθε βρόχος ενισχύει τη δική του χρήση μέχρι ο πόρος να υποβαθμιστεί για όλους."
+    },
+    "modules.analysis.decision_lens.archetype.tragedy_of_the_commons.leverage": {
+      "en": "Govern the shared resource collectively (shared limits, monitoring, allocation) — the collapse is not inevitable. Do not simply blame individual activities.",
+      "es": "Gobernar el recurso compartido de forma colectiva (límites compartidos, seguimiento, asignación): el colapso no es inevitable. No culpe simplemente a las actividades individuales.",
+      "fr": "Gouverner collectivement la ressource partagée (limites communes, suivi, allocation) — l'effondrement n'est pas inévitable. Ne blâmez pas simplement les activités individuelles.",
+      "de": "Die gemeinsame Ressource kollektiv steuern (gemeinsame Grenzen, Überwachung, Zuteilung) — der Kollaps ist nicht unvermeidlich. Nicht einfach einzelne Aktivitäten beschuldigen.",
+      "lt": "Bendrą išteklį valdykite kolektyviai (bendros ribos, stebėsena, paskirstymas) — žlugimas nėra neišvengiamas. Nekaltinkite vien atskirų veiklų.",
+      "pt": "Governar o recurso partilhado de forma coletiva (limites partilhados, monitorização, alocação) — o colapso não é inevitável. Não culpe apenas as atividades individuais.",
+      "it": "Governare la risorsa condivisa collettivamente (limiti condivisi, monitoraggio, allocazione) — il collasso non è inevitabile. Non incolpare semplicemente le singole attività.",
+      "no": "Styr den delte ressursen kollektivt (felles grenser, overvåking, fordeling) — kollapsen er ikke uunngåelig. Ikke bare klandre enkeltaktiviteter.",
+      "el": "Διαχειριστείτε τον κοινό πόρο συλλογικά (κοινά όρια, παρακολούθηση, κατανομή) — η κατάρρευση δεν είναι αναπόφευκτη. Μην κατηγορείτε απλώς τις μεμονωμένες δραστηριότητες."
+    },
+    "modules.analysis.decision_lens.archetype.limits_to_growth.name": {
+      "en": "Limits to Growth",
+      "es": "Límites del crecimiento",
+      "fr": "Limites à la croissance",
+      "de": "Grenzen des Wachstums",
+      "lt": "Augimo ribos",
+      "pt": "Limites do crescimento",
+      "it": "Limiti alla crescita",
+      "no": "Grenser for vekst",
+      "el": "Όρια στην ανάπτυξη"
+    },
+    "modules.analysis.decision_lens.archetype.limits_to_growth.desc": {
+      "en": "A reinforcing growth engine runs until a balancing (corrective) loop increasingly constrains it.",
+      "es": "Un motor de crecimiento reforzador funciona hasta que un bucle de equilibrio (correctivo) lo restringe cada vez más.",
+      "fr": "Un moteur de croissance renforçant fonctionne jusqu'à ce qu'une boucle d'équilibrage (corrective) le contraigne de plus en plus.",
+      "de": "Ein verstärkender Wachstumsmotor läuft, bis eine ausgleichende (korrigierende) Schleife ihn zunehmend einschränkt.",
+      "lt": "Stiprinantis augimo variklis veikia, kol balansuojantis (taisomasis) ciklas jį vis labiau riboja.",
+      "pt": "Um motor de crescimento reforçador funciona até que um ciclo de equilíbrio (corretivo) o restrinja cada vez mais.",
+      "it": "Un motore di crescita rinforzante funziona finché un ciclo di bilanciamento (correttivo) lo vincola sempre più.",
+      "no": "En forsterkende vekstmotor går til en balanserende (korrigerende) sløyfe i økende grad begrenser den.",
+      "el": "Ένας ενισχυτικός μηχανισμός ανάπτυξης λειτουργεί μέχρι ένας εξισορροπητικός (διορθωτικός) βρόχος να τον περιορίζει ολοένα και περισσότερο."
+    },
+    "modules.analysis.decision_lens.archetype.limits_to_growth.leverage": {
+      "en": "Do not push growth harder — ease the limiting constraint or strengthen the balancing response that checks it.",
+      "es": "No fuerce más el crecimiento: alivie la restricción limitante o refuerce la respuesta de equilibrio que lo controla.",
+      "fr": "Ne forcez pas davantage la croissance — assouplissez la contrainte limitante ou renforcez la réponse d'équilibrage qui la régule.",
+      "de": "Wachstum nicht stärker antreiben — die begrenzende Einschränkung lockern oder die ausgleichende Reaktion stärken, die es reguliert.",
+      "lt": "Nestumkite augimo dar labiau — sušvelninkite ribojantį suvaržymą arba sustiprinkite balansuojantį atsaką, kuris jį valdo.",
+      "pt": "Não force mais o crescimento — alivie a restrição limitante ou reforce a resposta de equilíbrio que o controla.",
+      "it": "Non spingere di più la crescita — allenta il vincolo limitante o rafforza la risposta di bilanciamento che la controlla.",
+      "no": "Ikke press veksten hardere — lett på den begrensende betingelsen eller styrk den balanserende responsen som demmer opp for den.",
+      "el": "Μην πιέζετε περισσότερο την ανάπτυξη — χαλαρώστε τον περιοριστικό παράγοντα ή ενισχύστε την εξισορροπητική απόκριση που τον ελέγχει."
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the **second half** of the Decision Lens — QSEM's archetype-identification phase
(Copilot's *"leverage-point explanation layer"*). **Stacked on #54** (base
`feat/decision-lens`); merge #54 first.

Detects **candidate system archetypes** from the feedback-loop structure and renders, per
archetype, a plain-language description + the **leverage element** with canon-aligned advice,
all under a standing "confirm with stakeholders" caveat.

## Shipped (2 of 4 archetypes — deliberately)
- **Tragedy of the Commons** — a shared State(MPF)/ES resource drawn on by ≥2 distinct
  Activities across ≥2 loops. Leverage = govern the shared resource. Prefers the stock (MPF)
  over the service (ES) and dedups by loop-set.
- **Limits to Growth** — the `GB→D` reinforcing engine coupled to a Response-mediated
  balancing loop. Leverage = the **Response** (never "intensify the Pressure").

## Deliberately NOT shipped (rationale in spec §6)
- **Fixes that Fail** — not structurally separable from Limits to Growth without delay/temporal
  data; these CLDs are untimed.
- **Shifting the Burden** — weak marine-SES literature support.

## Scientifically validated (sign-off in spec §6.1)
Ran the `scientific-validation` skill (scite peer-reviewed + WebSearch grey lit):
- Archetypes as an **ecological** intervention lens — **CONFIRMED** (Hallett & Hobbs 2020, *Restoration Ecology*).
- These archetypes on a real **marine lagoon fishery SES** — **CONFIRMED** (*Socio-Ecological Practice Research* 2021).
- Tragedy of the Commons / govern-the-resource leverage — **CONFIRMED**, with the Ostrom
  correction that collapse is **not inevitable** (Frischmann et al. 2019; Battersby/Ostrom 2017).
- The original "intensify the Pressure" advice — **CONTRADICTED**, removed.

This also corrected a topology error: valid DAPSIWRM cycles close via **either** `GB→D`
(reinforcing engine, no Response needed) **or** `R→{D,A,P,S}` (balancing) — verified against
`is_valid_dapsirwrm_transition` (23 rules).

## Verification
- `detect_archetypes` unit tests: **29 pass / 0 fail** (real `create_nodes_df`-shaped fixtures)
- module signature: **5**; i18n enforcement: **89** — all FAIL 0
- Full suite was validating at PR time; result to follow in a comment.

## Implementation notes
- Element type derived from id prefix (`dl_code_from_id`) — language-proof.
- 10 archetype i18n keys × 9 languages (machine-drafted; native review pending).
- Narrative now fuses quadrant × loop participation × archetype leverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
