### PR TITLE
fix(decision-lens): show Decision Lens in the simplified sidebar branch

### DIFF
--- a/MarineSABRES_SES_Shiny/functions/ui_sidebar.R
+++ b/MarineSABRES_SES_Shiny/functions/ui_sidebar.R
@@ -329,6 +329,11 @@ generate_sidebar_menu <- function(user_level = "intermediate", i18n) {
             safe_t("ui.sidebar.leverage_point_analysis", i18n_obj = i18n),
             tabName = "analysis_leverage",
             tooltip_text = safe_t("ui.sidebar.tooltip.leverage_point_analysis", i18n_obj = i18n)
+          ),
+          add_submenu_tooltip(
+            safe_t("ui.sidebar.decision_lens", i18n_obj = i18n),
+            tabName = "analysis_decision_lens",
+            tooltip_text = safe_t("ui.sidebar.tooltip.decision_lens", i18n_obj = i18n)
           )
         )
       ))


### PR DESCRIPTION
## Bug found via live verification
After deploying Decision Lens (1.19.0) to laguna, browser verification showed the **SES Analysis** sidebar submenu listing only **Loop Detection** and **Leverage Point Analysis** — **Decision Lens was missing**.

Root cause: `functions/ui_sidebar.R` has two analysis-menu branches — *simplified* (beginner / `show_all_analysis_tools = FALSE`) and *full*. The original wiring (#54) added the Decision Lens entry to the **full** branch only, but the deployed default renders the **simplified** branch, so default users couldn't reach the module. (The code review flagged this risk; the "full-only" call was wrong because the live default is simplified.)

## Fix
Add the same `add_submenu_tooltip(... tabName = "analysis_decision_lens" ...)` to the simplified branch. Uses the existing `ui.sidebar.decision_lens` / `ui.sidebar.tooltip.decision_lens` i18n keys (already present in all 9 languages). Now reachable in both user levels. Parse-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Decision Lens tool to the Analysis Tools menu in the sidebar, expanding available analysis options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->